### PR TITLE
feat(engine): declare namespace dependency graph (ADR-0003) + Packwerk packages — Role 4 PR-A

### DIFF
--- a/000-docs/003-AT-ARCH-architecture.md
+++ b/000-docs/003-AT-ARCH-architecture.md
@@ -41,11 +41,13 @@ Three layers enforce namespace integrity:
 
 | Layer | Mechanism | What it catches |
 |---|---|---|
-| 1 | Packwerk (`packwerk.yml` + per-namespace `package.yml`) | Cross-namespace imports not declared in `dependencies:` |
+| 1 | Packwerk (`packwerk.yml` + per-namespace `package.yml`; allowed-dependency graph in [ADR-0003](adr/ADR-0003-namespace-dependency-graph.md)) | Cross-namespace imports not declared in `dependencies:` |
 | 2 | RuboCop (`.rubocop.yml`) | Forbidden constants, missing `# frozen_string_literal: true`, conventions |
 | 3 | `# @api private` discipline | Symbols intended for internal use only; documented in CONTRIBUTING |
 
-A new top-level namespace requires an ADR amendment to ADR-0001. A new public API symbol on an existing namespace requires:
+The Packwerk graph is a four-tier DAG (Hooks → Telemetry / Analyzers / Skillops → CapabilityGate → Introspection + AdminTools); see [ADR-0003](adr/ADR-0003-namespace-dependency-graph.md) for the canonical edge list and rationale per edge.
+
+A new top-level namespace requires an ADR amendment to ADR-0001. A new inter-namespace edge requires an ADR amendment to ADR-0003. A new public API symbol on an existing namespace requires:
 
 1. Removing the `# @api private` tag
 2. Adding a CHANGELOG entry under that namespace's section

--- a/000-docs/003-AT-ARCH-architecture.md
+++ b/000-docs/003-AT-ARCH-architecture.md
@@ -47,6 +47,8 @@ Three layers enforce namespace integrity:
 
 The Packwerk graph is a four-tier DAG (Hooks → Telemetry / Analyzers / Skillops → CapabilityGate → Introspection + AdminTools); see [ADR-0003](adr/ADR-0003-namespace-dependency-graph.md) for the canonical edge list and rationale per edge.
 
+`lib/wild/schemas/` is shared data (YAML), not Ruby. It is intentionally **not a Packwerk package** — `packwerk.yml`'s `include: "lib/wild/**/*.rb"` glob already excludes it. The directory hosts cross-namespace data contracts (e.g., the F4-mandated `wildcard_corpus.yml` shared by `Wild::Analyzers::Permission` and `Wild::CapabilityGate`, and the `capability_gate/audit_event.yml` shape). Per [ADR-0003](adr/ADR-0003-namespace-dependency-graph.md), these shared data files form the schema-as-data substrate the council blessed under defense Point 6 — coupling through declared data, not through code reach-arounds.
+
 A new top-level namespace requires an ADR amendment to ADR-0001. A new inter-namespace edge requires an ADR amendment to ADR-0003. A new public API symbol on an existing namespace requires:
 
 1. Removing the `# @api private` tag

--- a/000-docs/adr/ADR-0003-namespace-dependency-graph.md
+++ b/000-docs/adr/ADR-0003-namespace-dependency-graph.md
@@ -1,0 +1,179 @@
+# ADR-0003: Namespace dependency graph — who may depend on whom
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Deciders:** Jeremy Longshore after Role 4 (engine architect) design
+**Relates to:** ADR-0001 (topology), ADR-0002 (namespace extraction policy)
+
+## Context
+
+ADR-0001 locked one `wild` gem with ten `Wild::*` namespaces.
+ADR-0002 governs when a namespace earns its own gemspec.
+
+Neither ADR specifies **which namespaces may depend on which other
+namespaces inside the merged gem.** Without an explicit dependency
+graph, every namespace can in principle reach into every other
+namespace's internals, recreating the hidden coupling problem the
+council named in defense Point 6 (honest dependency direction).
+
+The mechanism the council blessed for enforcing this is Packwerk
+per-namespace `package.yml`. This ADR declares the contract Packwerk
+enforces.
+
+## Decision
+
+Ten namespaces sit in a four-tier directed acyclic graph:
+
+```
+┌─ Tier 4 — transport surface (consumes everything below) ────────────────┐
+│                                                                         │
+│   Wild::Introspection      Wild::AdminTools                             │
+│   (lib/wild/introspection) (lib/wild/admin_tools)                       │
+│        ▲                          ▲                                     │
+└────────┼──────────────────────────┼──────────────────────────────────────┘
+         │                          │
+┌────────┴──────────────────────────┴─────────────────────────────────────┐
+│ Tier 3 — capability gate (gates Tier 4 admin calls)                     │
+│                                                                         │
+│   Wild::CapabilityGate                                                  │
+│   (lib/wild/capability_gate)                                            │
+│        ▲                                                                │
+└────────┼────────────────────────────────────────────────────────────────┘
+         │
+┌────────┴────────────────────────────────────────────────────────────────┐
+│ Tier 2 — analyzers + telemetry analysis (consume normalized data)       │
+│                                                                         │
+│   Wild::Analyzers::Permission   Wild::Analyzers::TestFlakes             │
+│   Wild::Telemetry::Analysis     Wild::Skillops                          │
+│        ▲                                                                │
+└────────┼────────────────────────────────────────────────────────────────┘
+         │
+┌────────┴────────────────────────────────────────────────────────────────┐
+│ Tier 1 — telemetry ingest + shared hooks (no internal deps)             │
+│                                                                         │
+│   Wild::Telemetry::Collector    Wild::Telemetry::Pipeline               │
+│   Wild::Hooks                                                           │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Allowed dependencies (the Packwerk contract)
+
+| Namespace | May depend on |
+|---|---|
+| `Wild::Hooks` | (no `Wild::` namespaces — shared concerns substrate) |
+| `Wild::Telemetry::Collector` | `Wild::Hooks` |
+| `Wild::Telemetry::Pipeline` | `Wild::Hooks`, `Wild::Telemetry::Collector` |
+| `Wild::Telemetry::Analysis` | `Wild::Hooks`, `Wild::Telemetry::Pipeline` |
+| `Wild::Analyzers::Permission` | `Wild::Hooks` |
+| `Wild::Analyzers::TestFlakes` | `Wild::Hooks`, `Wild::Telemetry::Analysis` |
+| `Wild::Skillops` | `Wild::Hooks` |
+| `Wild::CapabilityGate` | `Wild::Hooks`, `Wild::Analyzers::Permission` |
+| `Wild::Introspection` | `Wild::Hooks`, `Wild::CapabilityGate` |
+| `Wild::AdminTools` | `Wild::Hooks`, `Wild::CapabilityGate` |
+
+Engine-level files (`lib/wild.rb`, `lib/wild/engine.rb`,
+`lib/wild/configuration.rb`, `lib/wild/error.rb`, `lib/wild/version.rb`)
+are not packwerk-tracked; they form the engine substrate that every
+namespace inherits.
+
+### Forbidden patterns
+
+1. **Upward dependency.** A lower tier may NOT depend on a higher
+   tier. Example forbidden: `Wild::Telemetry::Collector` depends on
+   `Wild::CapabilityGate` (collector is Tier 1, gate is Tier 3).
+2. **Sideways dependency between admin and introspection.** They are
+   both Tier 4 and must remain independent — both go through Tier 3
+   (`Wild::CapabilityGate`) but never reach into each other.
+3. **Direct `Wild::Telemetry::Collector` ↔ `Wild::Telemetry::Analysis`
+   coupling.** Analysis only sees Pipeline-normalized events (F7 fix);
+   reaching into Collector bypasses the normalization seam.
+4. **Cycles of any kind.** Packwerk's `enforce_dependencies: true`
+   detects them.
+
+### Rationale
+
+- **`Wild::Hooks` as Tier 1 shared substrate.** Pike's per-repo review
+  surfaced `Wild::Hooks` as "channels-as-data-flow" — the place where
+  every namespace borrows shared concerns. Sits at the bottom so
+  everyone can use it; depends on no other `Wild::*` namespace.
+- **Telemetry pipeline layered top-to-bottom.** Kleppmann's normalize
+  step (F7) is what separates ingest (Collector) from analysis. Each
+  tier consumes only the layer below.
+- **CapabilityGate as Tier 3.** Has to come between the data tier
+  (Analyzers) and the transport tier (Introspection / AdminTools)
+  because every admin call passes through it (F2). Its dependency on
+  `Wild::Analyzers::Permission` is the policy-evaluation engine the
+  gate delegates to.
+- **Skillops as Tier 2.** Per F5, downgraded to internal namespace;
+  it's a reference data store consumed by higher tiers via explicit
+  query, never injecting itself.
+- **Introspection + AdminTools at Tier 4, independent siblings.** Both
+  speak MCP transport; both gate through `Wild::CapabilityGate`; neither
+  knows about the other. A consumer using only Introspection
+  (`bin/wild-mcp-introspection`) never loads AdminTools code.
+
+### Public-API surface (`# @api private` enforcement)
+
+Each namespace's `lib/wild/<ns>/` directory has an implicit two-tier
+shape:
+
+| Tier | Marker | Visible to |
+|---|---|---|
+| Public | None | Other namespaces (per the table above), engine, consumers |
+| Private | `# @api private` YARD tag on the constant or method | Only that namespace's own files |
+
+Packwerk's `enforce_privacy: true` enforces the marker at AST level.
+A symbol without `# @api private` is callable from any namespace that
+declares this namespace as a dependency.
+
+A NEW public symbol (introduced by removing `# @api private` OR a
+brand-new public class/method) requires:
+1. CHANGELOG entry under that namespace's section
+2. RSpec describing the public contract
+3. PR review by the namespace's CODEOWNERS
+
+These rules are documented in CONTRIBUTING.md (PR-F of Role 4).
+
+## Consequences
+
+### Positive
+
+- Coupling is provably bounded by the Packwerk graph.
+- A new contributor can see "who may import whom" at a glance.
+- Hidden cross-namespace coupling fails CI (Packwerk's
+  `enforce_dependencies: true`).
+- Sets the substrate Role 5 needs before code moves: each old gem's
+  `lib/` tree gets moved into a namespace dir, and that namespace's
+  package.yml declares what it may depend on. Cross-namespace imports
+  in the old code that violate this graph become beads to resolve
+  before the move completes.
+
+### Negative
+
+- Adding a new edge to the graph requires an ADR amendment. This is
+  intentional friction — the council wanted boundary changes to be
+  decisions, not drift.
+- The Tier 1 shared substrate (`Wild::Hooks`) can grow into a
+  god-namespace if not policed. Mitigation: per-namespace
+  `THREAT_MODEL.md` calls out what does NOT belong in Hooks.
+
+### Neutral / acknowledged
+
+- This ADR does NOT prescribe internal module structure inside each
+  namespace — that's per-namespace design. Packwerk only enforces the
+  inter-namespace contract.
+- The graph is the v0.1.0 baseline. ADR-0002 governs extraction; an
+  extracted namespace's gemspec inherits whatever dependencies its
+  package.yml declared.
+
+## Provenance
+
+- ADR-0001 (topology decision)
+- ADR-0002 (namespace extraction policy)
+- 000-docs/003-AT-ARCH-architecture.md § Boundary discipline
+- Council rev2 verdict §F4 (cross-namespace contract drift) +
+  §F7 (boundary normalization) — both informed the Tier 1 → Tier 4 layering
+- DHH per-repo merge table — confirms each namespace's archetype
+- Pike review of `wild-hook-ops` — informed `Wild::Hooks` as Tier 1
+- Kleppmann/Hickey on telemetry layering — informed Collector → Pipeline → Analysis chain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ section splits into a separate file.
 - Namespace directory placeholders under `lib/wild/`
 - ADR-0001 (topology — one gem, ten namespaces)
 - ADR-0002 (namespace extraction policy)
+- ADR-0003 (namespace dependency graph — four-tier DAG; Role 4 PR-A)
+- Root `package.yml` + ten per-namespace `package.yml` files encoding the ADR-0003 dependency contract; `packwerk.yml` lists each package path
 - 6-doc enterprise planning set under `000-docs/`
 
 ### Wild::Introspection

--- a/lib/wild/admin_tools/package.yml
+++ b/lib/wild/admin_tools/package.yml
@@ -1,0 +1,19 @@
+# Wild::AdminTools — Tier 4 admin operations over MCP.
+#
+# Per ADR-0003: privileged admin tools. Every public method MUST pass
+# through Wild::CapabilityGate#evaluate on at least one taint path
+# (council canonical; future custom CodeQL query
+# rb/wild/capability-gate-required will enforce this at AST level).
+#
+# DI container around Rails.cache / ActiveJob::Base / Flipper was DELETED
+# per DHH Week 2 plan; adapters are defaulted in this namespace's
+# configuration. Override points remain for consumers who need them.
+#
+# Forbidden coupling per ADR-0003: must NOT reach into Wild::Introspection
+# (both Tier 4; sibling namespaces).
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../hooks"
+  - "../capability_gate"

--- a/lib/wild/analyzers/permission/package.yml
+++ b/lib/wild/analyzers/permission/package.yml
@@ -1,0 +1,13 @@
+# Wild::Analyzers::Permission — Tier 2 permission model analyzer.
+#
+# Per ADR-0003: CLI + library. Provides policy-evaluation primitives that
+# Wild::CapabilityGate (Tier 3) delegates to. Fowler's `detect_cycle`
+# false-positive fix lives in this namespace.
+#
+# F4 fix: shares lib/wild/schemas/wildcard_corpus.yml with
+# Wild::CapabilityGate so the two cannot drift on wildcard matching.
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../../hooks"

--- a/lib/wild/analyzers/test_flakes/package.yml
+++ b/lib/wild/analyzers/test_flakes/package.yml
@@ -1,0 +1,12 @@
+# Wild::Analyzers::TestFlakes — Tier 2 test-flake forensics.
+#
+# Per ADR-0003: classifies test flakes from telemetry. Consumes
+# Wild::Telemetry::Analysis for upstream gap signal. Beck-mandated
+# golden corpus lives under spec/support/golden_corpora/test_flakes/
+# (Role 7 P1 ownership).
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../../hooks"
+  - "../../telemetry/analysis"

--- a/lib/wild/capability_gate/package.yml
+++ b/lib/wild/capability_gate/package.yml
@@ -1,0 +1,21 @@
+# Wild::CapabilityGate — Tier 3 policy evaluation + audit emission.
+#
+# Per ADR-0003: gates every admin operation (Tier 4 → CapabilityGate
+# → decision + audit). The highest-leverage namespace for security
+# correctness in the gem.
+#
+# F2 fix (Armstrong's most-leveraged finding): every rescue in this
+# namespace MUST emit a structured audit event AND deny the request.
+# :evaluation_error is hard-fail. Audit-liveness spec at
+# spec/wild/capability_gate/audit_liveness_spec.rb is Role 6 P1.
+#
+# F4 fix: shares lib/wild/schemas/wildcard_corpus.yml with
+# Wild::Analyzers::Permission (no drift).
+#
+# F6 fix: Session/Store wired in or deleted (Role 6 decision).
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../hooks"
+  - "../analyzers/permission"

--- a/lib/wild/hooks/package.yml
+++ b/lib/wild/hooks/package.yml
@@ -1,0 +1,14 @@
+# Wild::Hooks — Tier 1 shared-concerns substrate.
+#
+# Per ADR-0003: bottom of the namespace dependency graph. Houses hook
+# lifecycle, channels-as-data-flow patterns (Pike), and concerns shared
+# across every other namespace. Depends on no other Wild::* namespace
+# by design.
+#
+# Anti-pattern to police: do NOT let this become a god-namespace. If a
+# pattern only one namespace uses, it stays in that namespace. Hooks is
+# for patterns ≥ 2 namespaces will use.
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies: []

--- a/lib/wild/introspection/package.yml
+++ b/lib/wild/introspection/package.yml
@@ -1,0 +1,19 @@
+# Wild::Introspection — Tier 4 MCP transport surface.
+#
+# Per ADR-0003: safe runtime introspection (model schemas, routes,
+# config) over MCP. Shipped both as Rails-engine endpoint AND as
+# bin/wild-mcp-introspection standalone script (Karpathy-mandated
+# transport-host independence, MIN-Karpathy).
+#
+# F7: list_allowed_models discovery tool lives here (Role 9 P2).
+# MIN-Karpathy: tool descriptions versioned under prompts/introspection/;
+# response shapes under schemas/introspection/.
+#
+# Forbidden coupling per ADR-0003: must NOT reach into Wild::AdminTools
+# (both Tier 4; sibling namespaces).
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../hooks"
+  - "../capability_gate"

--- a/lib/wild/skillops/package.yml
+++ b/lib/wild/skillops/package.yml
@@ -1,0 +1,11 @@
+# Wild::Skillops — Tier 2 internal namespace (F5).
+#
+# Per ADR-0003 + council F5: downgraded from the old wild-skillops-registry
+# gem's v0.1.0 claims. NO atomicity, NO durability claims. Default
+# disabled via Wild.config.skillops.enabled = false. Earns its own
+# gemspec (per ADR-0002) only when a real external consumer appears.
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../hooks"

--- a/lib/wild/telemetry/analysis/package.yml
+++ b/lib/wild/telemetry/analysis/package.yml
@@ -1,0 +1,14 @@
+# Wild::Telemetry::Analysis — Tier 2 gap detection.
+#
+# Per ADR-0003: consumes Pipeline-normalized events. NEVER imports
+# Collector directly (F7 enforcement — reaching past Pipeline bypasses
+# the normalization seam).
+#
+# F8 (decomplect identity/value/time): Gap = (UUID, immutable record,
+# sequence number). This package's design is the locus of F8 work.
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../../hooks"
+  - "../pipeline"

--- a/lib/wild/telemetry/collector/package.yml
+++ b/lib/wild/telemetry/collector/package.yml
@@ -1,0 +1,14 @@
+# Wild::Telemetry::Collector — Tier 1 telemetry ingest.
+#
+# Per ADR-0003: privacy-aware session/event ingestion. Emits unstructured
+# events; Pipeline normalizes them in the next tier.
+#
+# F7 (boundary normalization): Collector MUST NOT be imported directly by
+# Wild::Telemetry::Analysis. Analysis consumes only normalized Pipeline
+# events. This package.yml enforces that contract — Collector is NOT in
+# Analysis's dependency list.
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../../hooks"

--- a/lib/wild/telemetry/pipeline/package.yml
+++ b/lib/wild/telemetry/pipeline/package.yml
@@ -1,0 +1,11 @@
+# Wild::Telemetry::Pipeline — Tier 1 telemetry normalization.
+#
+# Per ADR-0003: takes Collector's heterogeneous events and emits canonical
+# events with sequence numbers (Kleppmann's most-leveraged concession,
+# F7 fix). Only downstream consumer of Collector inside the gem.
+
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+  - "../../hooks"
+  - "../collector"

--- a/package.yml
+++ b/package.yml
@@ -1,0 +1,14 @@
+# Root Packwerk package — engine substrate.
+#
+# Governs the top-level engine files (lib/wild.rb, lib/wild/engine.rb,
+# lib/wild/configuration.rb, lib/wild/error.rb, lib/wild/version.rb).
+# The packwerk.yml already excludes these from per-namespace checks; this
+# file declares the root package's identity so Packwerk's introspection sees
+# a complete graph.
+#
+# Per ADR-0003: the engine substrate is at "tier 0" — every namespace
+# inherits it; it depends on no namespace.
+
+enforce_dependencies: true
+enforce_privacy: false # engine substrate is intentionally public to all namespaces
+dependencies: []

--- a/packwerk.yml
+++ b/packwerk.yml
@@ -1,11 +1,17 @@
 # Packwerk config — namespace-boundary lint for wild.
 #
-# Per ADR-0001 + 000-docs/003-AT-ARCH-architecture.md § "Boundary discipline":
-# each lib/wild/<namespace>/ becomes a Packwerk package in P1 (Role 4). This
-# root config exists from day one; per-namespace package.yml files land
-# alongside their code.
+# Per ADR-0001 (topology) + ADR-0003 (namespace dependency graph) +
+# 000-docs/003-AT-ARCH-architecture.md § "Boundary discipline": each
+# lib/wild/<namespace>/ is a Packwerk package with its own package.yml
+# declaring its allowed dependencies. Cross-namespace imports that
+# violate the ADR-0003 graph fail `bundle exec packwerk check`.
 #
 # Run: bundle exec packwerk check
+#
+# Note: CI marks the Packwerk job `continue-on-error: true` until Role 8
+# lands spec/dummy/ in P2 — Packwerk requires Rails-app context to boot.
+# Locally `bundle exec packwerk check` works when invoked from a host
+# Rails app that mounts Wild::Engine.
 
 include:
   - "lib/wild/**/*.rb"
@@ -19,7 +25,19 @@ exclude:
   - "lib/wild/engine.rb"
   - "lib/wild.rb"
 
+# Root + per-namespace packages.
+# Each entry is a glob that matches a directory containing a package.yml.
 package_paths:
-  - "lib/wild"
+  - "."
+  - "lib/wild/hooks"
+  - "lib/wild/skillops"
+  - "lib/wild/telemetry/collector"
+  - "lib/wild/telemetry/pipeline"
+  - "lib/wild/telemetry/analysis"
+  - "lib/wild/analyzers/permission"
+  - "lib/wild/analyzers/test_flakes"
+  - "lib/wild/capability_gate"
+  - "lib/wild/introspection"
+  - "lib/wild/admin_tools"
 
 custom_associations: []


### PR DESCRIPTION
## Summary

Role 4 (engine architect) **PR-A** — the architectural spec for who-may-depend-on-whom inside the merged gem, and the Packwerk substrate that enforces it. Lands the contract Role 5 needs before code can be moved out of the ten old \`wild-*\` gems.

## ADR-0003 — Namespace dependency graph

Four-tier DAG over ten namespaces:

\`\`\`
Tier 4   Wild::Introspection · Wild::AdminTools           (MCP transport surface)
              │                          │
              └────────────┬─────────────┘
                           ▼
Tier 3   Wild::CapabilityGate                              (policy + audit emission)
              ▲
              │
Tier 2   Wild::Telemetry::Analysis · Wild::Skillops        (consume normalized data)
         Wild::Analyzers::Permission · Wild::Analyzers::TestFlakes
              ▲
              │
Tier 1   Wild::Telemetry::Collector · Wild::Telemetry::Pipeline · Wild::Hooks
                                                            (ingest + shared substrate)
\`\`\`

The ADR enumerates every allowed edge row-by-row and lists four forbidden patterns:
1. Upward dependency from lower to higher tier
2. Sideways coupling between Introspection and AdminTools (both Tier 4)
3. Direct Collector ↔ Analysis coupling (bypasses Pipeline normalize seam — F7)
4. Cycles of any kind (Packwerk \`enforce_dependencies\` catches them)

## Packwerk substrate landed in this PR

| Path | Tier | Direct deps |
|---|---|---|
| \`package.yml\` (root) | 0 (substrate) | — |
| \`lib/wild/hooks/package.yml\` | 1 | — |
| \`lib/wild/telemetry/collector/package.yml\` | 1 | hooks |
| \`lib/wild/telemetry/pipeline/package.yml\` | 1 | hooks, collector |
| \`lib/wild/telemetry/analysis/package.yml\` | 2 | hooks, pipeline |
| \`lib/wild/analyzers/permission/package.yml\` | 2 | hooks |
| \`lib/wild/analyzers/test_flakes/package.yml\` | 2 | hooks, telemetry/analysis |
| \`lib/wild/skillops/package.yml\` | 2 | hooks |
| \`lib/wild/capability_gate/package.yml\` | 3 | hooks, analyzers/permission |
| \`lib/wild/introspection/package.yml\` | 4 | hooks, capability_gate |
| \`lib/wild/admin_tools/package.yml\` | 4 | hooks, capability_gate |

Every package.yml uses \`enforce_dependencies: true\` + \`enforce_privacy: true\` (except the root substrate). Privacy contract uses \`# @api private\` YARD tags; documentation lands in CONTRIBUTING.md (Role 4 **PR-F**).

## What this PR closes (design portion only)

The code-side fixes for these council findings still need Role 5 / Role 6 implementation; this PR locks the architectural contract those implementations must obey:

- \`wild-rvv.1.2\` F4 schemas-as-data design (shared \`wildcard_corpus\` between permission analyzer and capability gate)
- \`wild-rvv.5.1\` F7 boundary normalization (Collector → Pipeline → Analysis chain encoded in Tier 1 dependencies)
- \`wild-rvv.5.2\` F8 decomplect identity/value/time (Analysis depends only on Pipeline-normalized events)

## CI note

The Packwerk job remains \`continue-on-error: true\` until Role 8 lands \`spec/dummy/\` in P2 — Packwerk requires Rails-application context to introspect at runtime. The package.yml graph is correct independently of that infrastructure gap; once \`spec/dummy/\` lands, removing \`continue-on-error\` is a one-line change.

## Gate

Per yesterday's policy: \`martin-fowler-reviewer\` (stand-in for \`dhh-reviewer\`) signs this PR against ADR-0001 + ADR-0003 conformance before merge.

## Test plan

- [x] All 11 \`package.yml\` files are valid YAML
- [x] \`packwerk.yml\` lists all 11 paths
- [x] ADR-0003 references match the package.yml dependency lists exactly
- [x] No new \`*.rb\` files added (this is design-only)
- [ ] CI green
- [ ] Codecov upload visible on dashboard
- [ ] \`martin-fowler-reviewer\` signs against ADR-0001 conformance

## Next in Role 4

- PR-B Wild::Configuration typed nested accessors + spec (closes F1 design + implementation)
- PR-C Wild::Error hierarchy stubs + spec (closes MIN-Armstrong)
- PR-D Schemas-as-data layout in lib/wild/schemas/
- PR-E Pre-move Packwerk lint of the ten old wild-* gems → coupling-violation beads
- PR-F CONTRIBUTING.md @api-private discipline + Role-4-specific PR review process

- Jeremy Longshore
intentsolutions.io