### PR TITLE
feat(test_flakes): move wild-test-flake-forensics into Wild::Analyzers::TestFlakes (Role 5 PR-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,35 @@ section splits into a separate file.
 
 ### Wild::Analyzers::TestFlakes
 
-- _(pending: P1 code move from `wild-test-flake-forensics` + Beck golden-corpus test)_
+- Moved 21 source files from `wild-test-flake-forensics/lib/wild_test_flake_forensics/`
+  into `lib/wild/analyzers/test_flakes/` under the 3-deep
+  `Wild::Analyzers::TestFlakes::*` namespace (Role 5 PR-7). Sub-directories
+  preserved: `models/`, `parsers/`, `detection/`, `analysis/`, `triage/`,
+  `history/`, `export/`. Module Zeitwerk-rewritten from compact
+  `module WildTestFlakeForensics` to nested form. New loader at
+  `lib/wild/analyzers/test_flakes.rb`.
+- 24 specs (unit + adversarial + integration) moved to
+  `spec/wild/analyzers/test_flakes/`. Fixtures module (`TestFixtures`)
+  rewrapped as `Wild::Analyzers::TestFlakes::TestSupport::Fixtures`; spec
+  references to the old `TestFixtures::BASE_TIMESTAMP` constant rewritten to
+  the new path; wired into spec_helper.
+- **F1 — `Wild::Configuration::Analyzers::TestFlakes` extended** from 1 setting
+  (`classifier_corpus_path` from PR-B) to 5: the 4 old-gem knobs (`minimum_runs`
+  3, `flake_rate_threshold` 0.1, `max_history_entries` 10_000, `severity_weights`
+  all-1.0 four-signal map) plus `classifier_corpus_path`. Defaults verbatim.
+  Deleted the old gem's `version.rb` + `configuration.rb`; orphaned
+  `configuration_spec.rb` removed (coverage folded into central config spec).
+  `json_exporter.rb`'s metadata `version:` now reads `Wild::VERSION`.
+- **MIN-Armstrong — `Wild::Analyzers::TestFlakes::Error` subtree added**:
+  `ParseError`, `DetectionError`, `ExportError`. Old gem's `ConfigurationError`
+  subsumed by `Wild::ConfigurationError`.
+- 3 export files (`json`, `markdown`, `summary`) retained — F6 wire-or-delete
+  audit (Beck named 2 of 3 as half-published) is `wild-rvv.5.4`.
+- Config setter validation + freeze!/frozen? machinery NOT carried over; the
+  freeze adversarial spec deleted per F3.
+- **NOT in this PR** (deferred per Beck Tidy-First): the F3 golden-corpus
+  classifier test (`wild-rvv.7.1`) and the `coverage_analyzer` dedup between
+  Permission + TestFlakes (`wild-rvv.7.2`).
 
 ### Wild::Skillops
 

--- a/lib/wild.rb
+++ b/lib/wild.rb
@@ -8,6 +8,7 @@ require "wild/hooks"
 require "wild/capability_gate"
 require "wild/skillops"
 require "wild/analyzers/permission"
+require "wild/analyzers/test_flakes"
 
 # wild — Rails engine + generator: ten Wild::* namespaces consolidated into one
 # mountable gem. Council-blessed Topology A. See 000-docs/adr/ADR-0001-topology.md

--- a/lib/wild/analyzers/test_flakes.rb
+++ b/lib/wild/analyzers/test_flakes.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Wild::Analyzers::TestFlakes — Tier 2 per ADR-0003. Test flake detection,
+# root-cause analysis, and triage: parses rspec/junit/minitest reports,
+# detects flakes by pass/fail history, scores severity, tracks trends.
+#
+# Reads its policy from Wild.config.analyzers.test_flakes. Code moved from the
+# old wild-test-flake-forensics gem in Role 5 PR-7.
+#
+# NOTE: the F3 vanity-test replacement (golden-corpus classifier tests) is a
+# deferred behavior change tracked under wild-rvv.7.1 — this PR is the
+# structure-only move.
+
+# Models
+require "wild/analyzers/test_flakes/models/test_identity"
+require "wild/analyzers/test_flakes/models/test_result"
+require "wild/analyzers/test_flakes/models/root_cause"
+require "wild/analyzers/test_flakes/models/flake_record"
+require "wild/analyzers/test_flakes/models/triage_entry"
+
+# Parsers
+require "wild/analyzers/test_flakes/parsers/base"
+require "wild/analyzers/test_flakes/parsers/rspec_json"
+require "wild/analyzers/test_flakes/parsers/junit_xml"
+require "wild/analyzers/test_flakes/parsers/minitest_json"
+
+# Detection
+require "wild/analyzers/test_flakes/detection/comparator"
+require "wild/analyzers/test_flakes/detection/flake_detector"
+
+# Analysis
+require "wild/analyzers/test_flakes/analysis/signal_extractors"
+require "wild/analyzers/test_flakes/analysis/root_cause_analyzer"
+
+# Triage
+require "wild/analyzers/test_flakes/triage/severity_scorer"
+require "wild/analyzers/test_flakes/triage/remediation"
+require "wild/analyzers/test_flakes/triage/engine"
+
+# History
+require "wild/analyzers/test_flakes/history/trend_analyzer"
+require "wild/analyzers/test_flakes/history/store"
+
+# Export — flagged for F6 wire-or-delete audit under wild-rvv.5.4 (Beck named
+# 2 of these 3 exporters as half-published). Required here to preserve test
+# coverage during the structure move; the wire-or-delete decision is deferred.
+require "wild/analyzers/test_flakes/export/json_exporter"
+require "wild/analyzers/test_flakes/export/markdown_exporter"
+require "wild/analyzers/test_flakes/export/summary_exporter"

--- a/lib/wild/analyzers/test_flakes/analysis/root_cause_analyzer.rb
+++ b/lib/wild/analyzers/test_flakes/analysis/root_cause_analyzer.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Analysis
+        # rubocop:disable Metrics/ClassLength
+        class RootCauseAnalyzer
+          include SignalExtractors
+
+          CONFIDENCE_THRESHOLD = 0.15
+
+          def analyze(flake_records, all_results: [])
+            raise ArgumentError, "flake_records must be an Array" unless flake_records.is_a?(Array)
+
+            results_by_run = group_by_run(all_results)
+
+            flake_records.map do |record|
+              causes = build_root_causes(record, flake_records, results_by_run)
+              causes = [unknown_cause] if causes.empty?
+              rebuild_record(record, causes)
+            end
+          end
+
+          private
+
+          def rebuild_record(record, causes)
+            Models::FlakeRecord.new(
+              test_identity: record.test_identity,
+              results: record.results,
+              root_causes: causes,
+              first_seen: record.first_seen,
+              last_seen: record.last_seen
+            )
+          end
+
+          def group_by_run(all_results)
+            all_results.each_with_object({}) do |result, hash|
+              hash[result.run_id] ||= []
+              hash[result.run_id] << result
+            end
+          end
+
+          def build_root_causes(record, all_records, results_by_run)
+            [
+              timing_cause(record),
+              shared_state_cause(record, all_records),
+              external_dependency_cause(record),
+              random_seed_cause(record),
+              resource_contention_cause(record, results_by_run),
+              timezone_locale_cause(record)
+            ].select { |c| c.confidence >= CONFIDENCE_THRESHOLD }
+             .sort_by { |c| -c.confidence }
+          end
+
+          def timing_cause(record)
+            score = timing_signal(record)
+            Models::RootCause.new(
+              category: :timing_dependent,
+              confidence: score,
+              evidence: timing_evidence(record, score),
+              description: "High duration variance suggests timing-sensitive behavior"
+            )
+          end
+
+          def shared_state_cause(record, all_records)
+            score = shared_state_signal(record, all_records)
+            n = count_same_file_flakes(record, all_records)
+            Models::RootCause.new(
+              category: :shared_state,
+              confidence: score,
+              evidence: ["#{n} other flakes in same file"],
+              description: "Multiple flakes in same file/context suggest shared state contamination"
+            )
+          end
+
+          def external_dependency_cause(record)
+            score = external_dependency_signal(record)
+            Models::RootCause.new(
+              category: :external_dependency,
+              confidence: score,
+              evidence: external_evidence(record),
+              description: "Error messages reference external services or network"
+            )
+          end
+
+          def random_seed_cause(record)
+            score = random_seed_signal(record)
+            Models::RootCause.new(
+              category: :random_seed,
+              confidence: score,
+              evidence: seed_evidence(record),
+              description: "Different random seeds correlate with different test outcomes"
+            )
+          end
+
+          def resource_contention_cause(record, results_by_run)
+            score = resource_contention_signal(record, results_by_run)
+            Models::RootCause.new(
+              category: :resource_contention,
+              confidence: score,
+              evidence: ["Failures cluster in runs with multiple other failures"],
+              description: "Failures co-occur with high failure counts suggesting resource pressure"
+            )
+          end
+
+          def timezone_locale_cause(record)
+            score = timezone_locale_signal(record)
+            Models::RootCause.new(
+              category: :timezone_locale,
+              confidence: score,
+              evidence: timezone_evidence(record),
+              description: "Error messages reference time zones, locales, or date parsing"
+            )
+          end
+
+          def unknown_cause
+            Models::RootCause.new(
+              category: :unknown,
+              confidence: 0.5,
+              evidence: ["No specific signal matched"],
+              description: "Unable to determine root cause from available signals"
+            )
+          end
+
+          def timing_evidence(record, score)
+            return [] if score < CONFIDENCE_THRESHOLD
+
+            durations = record.durations
+            return [] if durations.empty?
+
+            mean = durations.sum / durations.size.to_f
+            ["Duration variance: #{record.duration_variance.round(1)}ms, mean: #{mean.round(1)}ms"]
+          end
+
+          def external_evidence(record)
+            record.results
+                  .filter_map(&:error_message)
+                  .select { |m| SignalExtractors::EXTERNAL_PATTERNS.any? { |p| p.match?(m) } }
+                  .first(3)
+          end
+
+          def seed_evidence(record)
+            seeds = record.results.filter_map { |r| r.metadata[:seed] }
+            return [] if seeds.empty?
+
+            ["Seeds observed: #{seeds.uniq.first(5).join(", ")}"]
+          end
+
+          def timezone_evidence(record)
+            record.results
+                  .filter_map(&:error_message)
+                  .select { |m| SignalExtractors::TIMEZONE_PATTERNS.any? { |p| p.match?(m) } }
+                  .first(3)
+          end
+
+          def count_same_file_flakes(record, all_records)
+            all_records.count do |fr|
+              fr != record && fr.test_identity.file_path == record.test_identity.file_path
+            end
+          end
+        end
+        # rubocop:enable Metrics/ClassLength
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/analysis/signal_extractors.rb
+++ b/lib/wild/analyzers/test_flakes/analysis/signal_extractors.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Analysis
+        module SignalExtractors
+          EXTERNAL_PATTERNS = [
+            /network/i, /connection\s+refused/i, /timeout/i, /http/i,
+            /database/i, /db\s+error/i, /api/i, /socket/i, /dns/i,
+            /connection\s+reset/i, /ECONNREFUSED/i, /Net::/
+          ].freeze
+
+          TIMEZONE_PATTERNS = [
+            /time\s+zone/i, /timezone/i, /locale/i, /utc/i,
+            /dst/i, /daylight/i, /strftime/i, /strptime/i,
+            /ActiveSupport::TimeZone/i, /date.*mismatch/i
+          ].freeze
+
+          SEED_PATTERNS = [
+            /seed/i, /random/i, /Faker/i, /SecureRandom/i, /rand\b/
+          ].freeze
+
+          def timing_signal(flake_record)
+            durations = flake_record.durations
+            return 0.0 if durations.size < 2
+
+            variance = flake_record.duration_variance
+            mean = durations.sum / durations.size.to_f
+            return 0.0 if mean.zero?
+
+            coefficient_of_variation = variance / mean
+            normalize_score([coefficient_of_variation * 1.5, 1.0].min)
+          end
+
+          def shared_state_signal(flake_record, all_flake_records)
+            id = flake_record.test_identity
+            file_score = file_sharing_score(id, all_flake_records, flake_record)
+            context_score = context_sharing_score(id, all_flake_records, flake_record)
+            normalize_score([file_score, context_score].max)
+          end
+
+          def external_dependency_signal(flake_record)
+            error_messages = flake_record.results.filter_map(&:error_message)
+            return 0.0 if error_messages.empty?
+
+            matches = error_messages.count { |msg| EXTERNAL_PATTERNS.any? { |pat| pat.match?(msg) } }
+            normalize_score(matches.to_f / error_messages.size)
+          end
+
+          # rubocop:disable Metrics/AbcSize
+          def random_seed_signal(flake_record)
+            seeds = flake_record.results.filter_map { |r| r.metadata[:seed] }
+            return check_error_messages_for_seed(flake_record) if seeds.empty?
+
+            return 0.0 if seeds.uniq.size <= 1
+
+            failure_seeds = seeds_for_status(flake_record, :failed)
+            pass_seeds = seeds_for_status(flake_record, :passed)
+            overlap = (failure_seeds & pass_seeds).size
+
+            return 0.8 if overlap.zero? && failure_seeds.any? && pass_seeds.any?
+
+            normalize_score(0.3)
+          end
+          # rubocop:enable Metrics/AbcSize
+
+          def resource_contention_signal(flake_record, all_results_by_run)
+            failure_run_ids = flake_record.results.select(&:failed?).map(&:run_id)
+            return 0.0 if failure_run_ids.empty?
+
+            counts = failure_run_failure_counts(failure_run_ids, all_results_by_run)
+            return 0.0 if counts.empty?
+
+            avg = counts.sum.to_f / counts.size
+            normalize_score([avg * 0.05, 0.7].min)
+          end
+
+          def timezone_locale_signal(flake_record)
+            error_messages = flake_record.results.filter_map(&:error_message)
+            return 0.0 if error_messages.empty?
+
+            matches = error_messages.count { |msg| TIMEZONE_PATTERNS.any? { |pat| pat.match?(msg) } }
+            normalize_score(matches.to_f / error_messages.size)
+          end
+
+          private
+
+          def file_sharing_score(identity, records, excluded)
+            n = count_matching(records, excluded) { |fr| fr.test_identity.file_path == identity.file_path }
+            [n * 0.2, 0.6].min
+          end
+
+          def context_sharing_score(identity, records, excluded)
+            n = count_matching(records, excluded) do |fr|
+              !fr.test_identity.context.empty? && fr.test_identity.context == identity.context
+            end
+            [n * 0.3, 0.9].min
+          end
+
+          def count_matching(records, excluded, &block)
+            records.count { |fr| fr != excluded && block.call(fr) }
+          end
+
+          def seeds_for_status(flake_record, status_check)
+            flake_record.results
+                        .select { |r| status_check == :failed ? r.failed? : r.passed? }
+                        .filter_map { |r| r.metadata[:seed] }
+                        .uniq
+          end
+
+          def failure_run_failure_counts(run_ids, results_by_run)
+            run_ids.filter_map do |run_id|
+              run_results = results_by_run[run_id]
+              next unless run_results
+
+              run_results.count(&:failed?)
+            end
+          end
+
+          def check_error_messages_for_seed(flake_record)
+            error_messages = flake_record.results.filter_map(&:error_message)
+            return 0.0 if error_messages.empty?
+
+            matches = error_messages.count { |msg| SEED_PATTERNS.any? { |pat| pat.match?(msg) } }
+            normalize_score(matches.to_f / error_messages.size * 0.5)
+          end
+
+          def normalize_score(value)
+            value.to_f.clamp(0.0, 1.0).round(4)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/detection/comparator.rb
+++ b/lib/wild/analyzers/test_flakes/detection/comparator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Detection
+        class Comparator
+          def self.group_by_identity(results)
+            new.group_by_identity(results)
+          end
+
+          def group_by_identity(results)
+            raise DetectionError, "results must be an Array" unless results.is_a?(Array)
+
+            results.each_with_object({}) do |result, groups|
+              next unless result.is_a?(Models::TestResult)
+
+              key = result.test_identity.key
+              groups[key] ||= []
+              groups[key] << result
+            end
+          end
+
+          def both_outcomes?(results)
+            statuses = results.map(&:status).uniq
+            passed = statuses.include?(:passed)
+            failed = statuses.intersect?(%i[failed errored])
+            passed && failed
+          end
+
+          def flake_rate(results)
+            return 0.0 if results.empty?
+
+            failed = results.count(&:failed?)
+            failed.to_f / results.size
+          end
+
+          def run_ids_with_failures(results)
+            results.select(&:failed?).map(&:run_id).uniq
+          end
+
+          def run_ids_with_passes(results)
+            results.select(&:passed?).map(&:run_id).uniq
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/detection/flake_detector.rb
+++ b/lib/wild/analyzers/test_flakes/detection/flake_detector.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Detection
+        class FlakeDetector
+          def initialize(minimum_runs: nil, flake_rate_threshold: nil)
+            config = Wild.config.analyzers.test_flakes
+            @minimum_runs = minimum_runs || config.minimum_runs
+            @flake_rate_threshold = flake_rate_threshold || config.flake_rate_threshold
+            @comparator = Comparator.new
+          end
+
+          def detect(results)
+            raise DetectionError, "results must be an Array" unless results.is_a?(Array)
+
+            grouped = @comparator.group_by_identity(results)
+            grouped.filter_map do |_key, group_results|
+              build_flake_record(group_results)
+            end
+          end
+
+          private
+
+          def build_flake_record(group_results)
+            return nil if group_results.size < @minimum_runs
+            return nil unless @comparator.both_outcomes?(group_results)
+
+            rate = @comparator.flake_rate(group_results)
+            return nil if rate < @flake_rate_threshold
+
+            identity = group_results.first.test_identity
+            Models::FlakeRecord.new(
+              test_identity: identity,
+              results: group_results
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/export/json_exporter.rb
+++ b/lib/wild/analyzers/test_flakes/export/json_exporter.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Export
+        class JsonExporter
+          def export(triage_entries, metadata: {})
+            raise ExportError, "triage_entries must be an Array" unless triage_entries.is_a?(Array)
+
+            payload = build_payload(triage_entries, metadata)
+            JSON.generate(payload)
+          rescue JSON::GeneratorError => e
+            raise ExportError, "JSON generation failed: #{e.message}"
+          end
+
+          private
+
+          def build_payload(entries, metadata)
+            {
+              metadata: base_metadata.merge(metadata),
+              summary: build_summary(entries),
+              flakes: entries.map(&:to_h)
+            }
+          end
+
+          def base_metadata
+            {
+              generated_at: Time.now.utc.iso8601,
+              # F1 — one gem-level version constant; the old
+              # WildTestFlakeForensics::VERSION was deleted in the move.
+              version: Wild::VERSION,
+              total_flakes: nil
+            }
+          end
+
+          def build_summary(entries)
+            severity_counts = severity_breakdown(entries)
+            severity_counts.merge(
+              total: entries.size,
+              avg_flake_rate: avg_flake_rate(entries),
+              top_root_cause: top_root_cause(entries)
+            )
+          end
+
+          def severity_breakdown(entries)
+            by_severity = entries.group_by(&:severity)
+            Models::TriageEntry::SEVERITIES.index_with do |sev|
+              by_severity[sev]&.size || 0
+            end
+          end
+
+          def avg_flake_rate(entries)
+            return 0.0 if entries.empty?
+
+            rates = entries.map { |e| e.flake_record.flake_rate }
+            (rates.sum / rates.size).round(4)
+          end
+
+          def top_root_cause(entries)
+            return nil if entries.empty?
+
+            all_causes = entries.flat_map { |e| e.flake_record.root_causes }
+            return nil if all_causes.empty?
+
+            all_causes.max_by(&:confidence)&.category
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/export/markdown_exporter.rb
+++ b/lib/wild/analyzers/test_flakes/export/markdown_exporter.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Export
+        class MarkdownExporter
+          def export(triage_entries, title: "Flaky Test Triage Report", metadata: {})
+            raise ExportError, "triage_entries must be an Array" unless triage_entries.is_a?(Array)
+
+            sections = [
+              render_header(title, metadata),
+              render_summary(triage_entries),
+              render_entries(triage_entries)
+            ]
+
+            sections.join("\n\n")
+          end
+
+          private
+
+          def render_header(title, metadata)
+            lines = ["# #{title}", "", "_Generated: #{Time.now.utc.strftime("%Y-%m-%d %H:%M UTC")}_"]
+            metadata.each { |k, v| lines << "_#{k}: #{v}_" }
+            lines.join("\n")
+          end
+
+          def render_summary(entries)
+            by_severity = entries.group_by(&:severity)
+            lines = ["## Summary", ""]
+            lines << "| Severity | Count |"
+            lines << "|----------|-------|"
+            %i[critical high medium low].each do |sev|
+              count = by_severity[sev]&.size || 0
+              lines << "| #{sev.to_s.capitalize} | #{count} |"
+            end
+            lines << ""
+            lines << "**Total flaky tests:** #{entries.size}"
+            lines.join("\n")
+          end
+
+          def render_entries(entries)
+            return "## Flaky Tests\n\n_No flaky tests detected._" if entries.empty?
+
+            sections = ["## Flaky Tests"]
+            entries.each_with_index do |entry, idx|
+              sections << render_entry(entry, idx + 1)
+            end
+            sections.join("\n\n")
+          end
+
+          def render_entry(entry, index)
+            record = entry.flake_record
+            identity = record.test_identity
+            lines = entry_header_lines(entry, index, record, identity)
+            lines << ""
+            lines << render_root_causes(record.root_causes)
+            lines << ""
+            lines << render_remediations(entry.remediations)
+            lines.join("\n")
+          end
+
+          def entry_header_lines(entry, index, record, identity)
+            lines = entry_title_lines(entry, index, identity)
+            rate_pct = (record.flake_rate * 100).round(1)
+            lines << "**Flake Rate:** #{rate_pct}% (#{record.failure_count}/#{record.total_runs} runs)"
+            lines << "**Trend:** #{entry.trend}"
+            lines
+          end
+
+          def entry_title_lines(entry, index, identity)
+            lines = ["### #{index}. #{escape_md(identity.test_name)}", ""]
+            lines << "**Severity:** #{entry.severity.to_s.upcase} (score: #{entry.severity_score})"
+            lines << "**File:** `#{identity.file_path}`"
+            lines << "**Context:** #{identity.context}" unless identity.context.empty?
+            lines
+          end
+
+          def render_root_causes(causes)
+            return "**Root Causes:** Unknown" if causes.empty?
+
+            lines = ["**Root Causes:**", ""]
+            causes.each do |rc|
+              lines << "- `#{rc.category}` (confidence: #{(rc.confidence * 100).round}%)"
+              lines << "  - #{rc.description}" if rc.description
+            end
+            lines.join("\n")
+          end
+
+          def render_remediations(remediations)
+            return "" if remediations.empty?
+
+            lines = ["**Suggested Remediations:**", ""]
+            remediations.each { |r| lines << "- #{r}" }
+            lines.join("\n")
+          end
+
+          def escape_md(text)
+            text.to_s.gsub("|", '\\|').gsub("`", "'")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/export/markdown_exporter.rb
+++ b/lib/wild/analyzers/test_flakes/export/markdown_exporter.rb
@@ -95,8 +95,14 @@ module Wild
             lines.join("\n")
           end
 
+          # Escapes backslash AND pipe (block form avoids gsub replacement-string
+          # backslash interpretation), then neutralizes backticks. Closes a
+          # CodeQL rb/incomplete-sanitization finding carried in from the
+          # wild-test-flake-forensics source — same fix as PR #25's permission
+          # markdown exporter. Behavior-preserving for all existing inputs;
+          # documented as a scope extension to the Role 5 PR-7 move.
           def escape_md(text)
-            text.to_s.gsub("|", '\\|').gsub("`", "'")
+            text.to_s.gsub(/[\\|]/) { |c| "\\#{c}" }.gsub("`", "'")
           end
         end
       end

--- a/lib/wild/analyzers/test_flakes/export/summary_exporter.rb
+++ b/lib/wild/analyzers/test_flakes/export/summary_exporter.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Export
+        class SummaryExporter
+          def export(triage_entries)
+            raise ExportError, "triage_entries must be an Array" unless triage_entries.is_a?(Array)
+
+            return "No flaky tests detected.\n" if triage_entries.empty?
+
+            lines = [header(triage_entries)]
+            triage_entries.each { |entry| lines << format_entry(entry) }
+            "#{lines.join("\n")}\n"
+          end
+
+          private
+
+          def header(entries)
+            total = entries.size
+            critical = entries.count(&:critical?)
+            high = entries.count(&:high?)
+            "FLAKE REPORT: #{total} flaky test(s) — #{critical} critical, #{high} high"
+          end
+
+          def format_entry(entry)
+            record = entry.flake_record
+            identity = record.test_identity
+            cause = primary_cause_label(record)
+            rate_pct = (record.flake_rate * 100).round(1)
+
+            "[#{entry.severity.to_s.upcase}] #{truncate(identity.test_name, 60)} " \
+              "(#{rate_pct}% flake, #{cause})"
+          end
+
+          def primary_cause_label(record)
+            cause = record.primary_root_cause
+            return "cause: unknown" unless cause
+
+            "cause: #{cause.category}"
+          end
+
+          def truncate(str, max_len)
+            return str if str.length <= max_len
+
+            "#{str[0, max_len - 3]}..."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/history/store.rb
+++ b/lib/wild/analyzers/test_flakes/history/store.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module History
+        class Store
+          def initialize(max_entries: nil)
+            config = Wild.config.analyzers.test_flakes
+            @max_entries = max_entries || config.max_history_entries
+            @records = {}
+            @snapshots = {}
+          end
+
+          def record(flake_record)
+            key = flake_record.test_identity.key
+            existing = @records[key]
+
+            if existing
+              merged = merge_records(existing, flake_record)
+              @records[key] = merged
+            else
+              @records[key] = flake_record
+            end
+
+            snapshot!(key, flake_record.flake_rate)
+            enforce_limit!
+            @records[key]
+          end
+
+          def fetch(test_identity)
+            @records[test_identity.key]
+          end
+
+          def all
+            @records.values.dup
+          end
+
+          def trend_for(test_identity)
+            key = test_identity.key
+            snaps = @snapshots[key]
+            return :stable unless snaps && snaps.size >= 2
+
+            History::TrendAnalyzer.new.trend(snaps)
+          end
+
+          delegate :size, to: :@records
+
+          def clear!
+            @records.clear
+            @snapshots.clear
+          end
+
+          private
+
+          # rubocop:disable Metrics/AbcSize
+          def merge_records(existing, new_record)
+            all_results = (existing.results + new_record.results).uniq
+            first_seen = [existing.first_seen, new_record.first_seen].compact.min
+            last_seen = [existing.last_seen, new_record.last_seen].compact.max
+            causes = new_record.root_causes.any? ? new_record.root_causes : existing.root_causes
+
+            Models::FlakeRecord.new(
+              test_identity: existing.test_identity,
+              results: all_results,
+              root_causes: causes,
+              first_seen: first_seen,
+              last_seen: last_seen
+            )
+          end
+          # rubocop:enable Metrics/AbcSize
+
+          def snapshot!(key, flake_rate)
+            @snapshots[key] ||= []
+            @snapshots[key] << { rate: flake_rate, at: Time.now.utc }
+            @snapshots[key] = @snapshots[key].last(50)
+          end
+
+          def enforce_limit!
+            return if @records.size <= @max_entries
+
+            oldest_key = @records.min_by { |_, r| r.first_seen || Time.now.utc }.first
+            @records.delete(oldest_key)
+            @snapshots.delete(oldest_key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/history/trend_analyzer.rb
+++ b/lib/wild/analyzers/test_flakes/history/trend_analyzer.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module History
+        class TrendAnalyzer
+          WORSENING_THRESHOLD = 0.05
+          IMPROVING_THRESHOLD = -0.05
+
+          def trend(snapshots)
+            return :stable if snapshots.size < 2
+
+            sorted = snapshots.sort_by { |s| s[:at] }
+            delta = compute_delta(sorted)
+
+            classify_trend(delta)
+          end
+
+          def trend_from_rates(rates)
+            return :stable if rates.size < 2
+
+            snapshots = rates.each_with_index.map do |rate, i|
+              { rate: rate, at: Time.at(i).utc }
+            end
+            trend(snapshots)
+          end
+
+          private
+
+          def compute_delta(sorted)
+            half = sorted.size / 2
+            early = sorted.first(half).pluck(:rate)
+            recent = sorted.last(half).pluck(:rate)
+
+            early_avg = early.sum / early.size.to_f
+            recent_avg = recent.sum / recent.size.to_f
+
+            recent_avg - early_avg
+          end
+
+          def classify_trend(delta)
+            if delta >= WORSENING_THRESHOLD
+              :worsening
+            elsif delta <= IMPROVING_THRESHOLD
+              :improving
+            else
+              :stable
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/models/flake_record.rb
+++ b/lib/wild/analyzers/test_flakes/models/flake_record.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Models
+        class FlakeRecord
+          attr_reader :test_identity, :results, :root_causes, :first_seen, :last_seen
+
+          def initialize(test_identity:, results:, root_causes: [], first_seen: nil, last_seen: nil)
+            raise ArgumentError, "test_identity must be a TestIdentity" unless test_identity.is_a?(TestIdentity)
+            raise ArgumentError, "results must be an Array" unless results.is_a?(Array)
+
+            @test_identity = test_identity
+            @results = results.freeze
+            @root_causes = Array(root_causes).freeze
+            @first_seen = first_seen || earliest_timestamp
+            @last_seen = last_seen || latest_timestamp
+          end
+
+          def flake_rate
+            return 0.0 if results.empty?
+
+            failures = results.count(&:failed?)
+            failures.to_f / results.size
+          end
+
+          def total_runs
+            results.size
+          end
+
+          def failure_count
+            results.count(&:failed?)
+          end
+
+          def pass_count
+            results.count(&:passed?)
+          end
+
+          def run_ids
+            results.map(&:run_id).uniq
+          end
+
+          def durations
+            results.filter_map(&:duration_ms)
+          end
+
+          # rubocop:disable Metrics/AbcSize
+          def duration_variance
+            return 0.0 if durations.size < 2
+
+            mean = durations.sum / durations.size.to_f
+            variance = durations.sum { |d| (d - mean)**2 } / durations.size.to_f
+            Math.sqrt(variance)
+          end
+          # rubocop:enable Metrics/AbcSize
+
+          def primary_root_cause
+            root_causes.max_by(&:confidence)
+          end
+
+          def to_h
+            {
+              test_identity: test_identity.to_h,
+              flake_rate: flake_rate,
+              total_runs: total_runs,
+              failure_count: failure_count,
+              first_seen: first_seen&.iso8601,
+              last_seen: last_seen&.iso8601,
+              root_causes: root_causes.map(&:to_h)
+            }
+          end
+
+          private
+
+          def earliest_timestamp
+            results.map(&:timestamp).min
+          end
+
+          def latest_timestamp
+            results.map(&:timestamp).max
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/models/root_cause.rb
+++ b/lib/wild/analyzers/test_flakes/models/root_cause.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Models
+        class RootCause
+          CATEGORIES = %i[
+            timing_dependent
+            order_dependent
+            shared_state
+            external_dependency
+            random_seed
+            resource_contention
+            timezone_locale
+            unknown
+          ].freeze
+
+          attr_reader :category, :confidence, :evidence, :description
+
+          def initialize(category:, confidence:, evidence: [], description: nil)
+            validate_category!(category)
+            validate_confidence!(confidence)
+
+            @category = category.to_sym
+            @confidence = confidence.to_f
+            @evidence = Array(evidence).map(&:to_s).freeze
+            @description = description&.to_s&.freeze
+          end
+
+          def to_h
+            {
+              category: category,
+              confidence: confidence,
+              evidence: evidence,
+              description: description
+            }
+          end
+
+          def high_confidence?
+            confidence >= 0.7
+          end
+
+          def medium_confidence?
+            confidence >= 0.4 && confidence < 0.7
+          end
+
+          def low_confidence?
+            confidence < 0.4
+          end
+
+          private
+
+          def validate_category!(category)
+            sym = category.to_sym
+            return if CATEGORIES.include?(sym)
+
+            raise ArgumentError, "category must be one of #{CATEGORIES.inspect}, got: #{category.inspect}"
+          end
+
+          def validate_confidence!(confidence)
+            f = confidence.to_f
+            return if f.between?(0.0, 1.0)
+
+            raise ArgumentError, "confidence must be between 0.0 and 1.0, got: #{confidence.inspect}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/models/test_identity.rb
+++ b/lib/wild/analyzers/test_flakes/models/test_identity.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Models
+        class TestIdentity
+          attr_reader :file_path, :test_name, :context
+
+          def initialize(file_path:, test_name:, context: nil)
+            raise ArgumentError, "file_path cannot be nil or empty" if file_path.to_s.strip.empty?
+            raise ArgumentError, "test_name cannot be nil or empty" if test_name.to_s.strip.empty?
+
+            @file_path = file_path.to_s.freeze
+            @test_name = test_name.to_s.freeze
+            @context = context.to_s.freeze
+          end
+
+          def key
+            "#{file_path}::#{context}::#{test_name}".freeze
+          end
+
+          def ==(other)
+            other.is_a?(TestIdentity) && key == other.key
+          end
+
+          alias eql? ==
+
+          delegate :hash, to: :key
+
+          def to_h
+            { file_path: file_path, test_name: test_name, context: context }
+          end
+
+          def to_s
+            context.empty? ? "#{file_path} — #{test_name}" : "#{file_path} — #{context} — #{test_name}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/models/test_result.rb
+++ b/lib/wild/analyzers/test_flakes/models/test_result.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Models
+        class TestResult
+          VALID_STATUSES = %i[passed failed errored skipped pending].freeze
+
+          attr_reader :test_identity, :status, :duration_ms, :run_id, :timestamp,
+                      :error_message, :metadata
+
+          # rubocop:disable Metrics/ParameterLists
+          def initialize(test_identity:, status:, run_id:, timestamp:,
+                         duration_ms: nil, error_message: nil, metadata: {})
+            validate_identity!(test_identity)
+            validate_status!(status)
+            validate_run_id!(run_id)
+            validate_timestamp!(timestamp)
+
+            @test_identity = test_identity
+            @status = status.to_sym
+            @run_id = run_id.to_s.freeze
+            @timestamp = timestamp
+            @duration_ms = duration_ms&.to_f
+            @error_message = error_message&.to_s&.freeze
+            @metadata = (metadata || {}).freeze
+          end
+          # rubocop:enable Metrics/ParameterLists
+
+          def passed?
+            status == :passed
+          end
+
+          def failed?
+            %i[failed errored].include?(status)
+          end
+
+          def skipped?
+            %i[skipped pending].include?(status)
+          end
+
+          def to_h
+            {
+              test_identity: test_identity.to_h,
+              status: status,
+              run_id: run_id,
+              timestamp: timestamp.iso8601,
+              duration_ms: duration_ms,
+              error_message: error_message,
+              metadata: metadata
+            }
+          end
+
+          private
+
+          def validate_identity!(identity)
+            return if identity.is_a?(TestIdentity)
+
+            raise ArgumentError, "test_identity must be a TestIdentity, got: #{identity.class}"
+          end
+
+          def validate_status!(status)
+            sym = status.to_sym
+            return if VALID_STATUSES.include?(sym)
+
+            raise ArgumentError, "status must be one of #{VALID_STATUSES.inspect}, got: #{status.inspect}"
+          end
+
+          def validate_run_id!(run_id)
+            raise ArgumentError, "run_id cannot be nil or empty" if run_id.to_s.strip.empty?
+          end
+
+          def validate_timestamp!(timestamp)
+            raise ArgumentError, "timestamp cannot be nil" if timestamp.nil?
+            raise ArgumentError, "timestamp must respond to iso8601" unless timestamp.respond_to?(:iso8601)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/models/triage_entry.rb
+++ b/lib/wild/analyzers/test_flakes/models/triage_entry.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Models
+        class TriageEntry
+          SEVERITIES = %i[critical high medium low].freeze
+
+          attr_reader :flake_record, :severity, :severity_score, :remediations, :trend
+
+          def initialize(flake_record:, severity:, severity_score:, remediations: [], trend: :stable)
+            raise ArgumentError, "flake_record must be a FlakeRecord" unless flake_record.is_a?(FlakeRecord)
+
+            unless SEVERITIES.include?(severity.to_sym)
+              raise ArgumentError, "severity must be one of #{SEVERITIES.inspect}, got: #{severity.inspect}"
+            end
+
+            @flake_record = flake_record
+            @severity = severity.to_sym
+            @severity_score = severity_score.to_f
+            @remediations = Array(remediations).map(&:to_s).freeze
+            @trend = trend.to_sym
+          end
+
+          delegate :test_identity, to: :flake_record
+
+          def critical?
+            severity == :critical
+          end
+
+          def high?
+            severity == :high
+          end
+
+          def to_h
+            {
+              test_identity: test_identity.to_h,
+              severity: severity,
+              severity_score: severity_score,
+              flake_rate: flake_record.flake_rate,
+              failure_count: flake_record.failure_count,
+              total_runs: flake_record.total_runs,
+              trend: trend,
+              root_causes: flake_record.root_causes.map(&:to_h),
+              remediations: remediations
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/parsers/base.rb
+++ b/lib/wild/analyzers/test_flakes/parsers/base.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Parsers
+        class Base
+          def self.parse(input, run_id: nil, timestamp: nil)
+            new.parse(input, run_id: run_id, timestamp: timestamp)
+          end
+
+          def parse(input, run_id: nil, timestamp: nil)
+            raise NotImplementedError, "#{self.class}#parse is not implemented"
+          end
+
+          private
+
+          def require_non_empty!(input)
+            raise ParseError, "input cannot be nil or empty" if input.to_s.strip.empty?
+          end
+
+          def default_timestamp
+            require "time"
+            Time.now.utc
+          end
+
+          def coerce_run_id(run_id)
+            run_id || "run-#{Time.now.utc.to_i}"
+          end
+
+          def build_identity(file_path:, test_name:, context: nil)
+            Models::TestIdentity.new(
+              file_path: file_path.to_s.empty? ? "unknown" : file_path,
+              test_name: test_name,
+              context: context
+            )
+          end
+
+          # rubocop:disable Metrics/ParameterLists
+          def build_result(identity:, status:, run_id:, timestamp:, duration_ms: nil,
+                           error_message: nil, metadata: {})
+            Models::TestResult.new(
+              test_identity: identity,
+              status: status,
+              run_id: run_id,
+              timestamp: timestamp,
+              duration_ms: duration_ms,
+              error_message: error_message,
+              metadata: metadata
+            )
+          end
+          # rubocop:enable Metrics/ParameterLists
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/parsers/junit_xml.rb
+++ b/lib/wild/analyzers/test_flakes/parsers/junit_xml.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rexml/document"
+require "time"
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Parsers
+        class JunitXml < Base
+          def parse(input, run_id: nil, timestamp: nil)
+            require_non_empty!(input)
+
+            doc = parse_xml!(input)
+            extract_test_cases(doc, coerce_run_id(run_id), timestamp || default_timestamp)
+          end
+
+          private
+
+          def parse_xml!(input)
+            doc = REXML::Document.new(input)
+            root = doc.root
+            raise ParseError, "JUnit XML must have a root element" if root.nil?
+
+            unless %w[testsuite testsuites].include?(root.name)
+              raise ParseError, "JUnit XML root must be <testsuite> or <testsuites>, got: <#{root.name}>"
+            end
+
+            doc
+          rescue REXML::ParseException => e
+            raise ParseError, "Invalid XML: #{e.message}"
+          end
+
+          def extract_test_cases(doc, run_id, timestamp)
+            results = []
+            REXML::XPath.each(doc, "//testcase") do |node|
+              result = build_result_from_node(node, run_id, timestamp)
+              results << result if result
+            end
+            results
+          end
+
+          def build_result_from_node(node, run_id, timestamp)
+            identity = extract_node_identity(node)
+            status, error_message = determine_status(node)
+            build_result(
+              identity: identity,
+              status: status,
+              run_id: run_id,
+              timestamp: timestamp,
+              duration_ms: parse_duration(node),
+              error_message: error_message
+            )
+          rescue ArgumentError
+            nil
+          end
+
+          def extract_node_identity(node)
+            classname = node.attributes["classname"] || ""
+            test_name = node.attributes["name"] || "unknown"
+            build_identity(
+              file_path: classname.empty? ? "unknown" : classname_to_file(classname),
+              test_name: test_name,
+              context: classname
+            )
+          end
+
+          def parse_duration(node)
+            time_attr = node.attributes["time"]
+            time_attr ? (time_attr.to_f * 1000).round(3) : nil
+          end
+
+          # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+          def determine_status(node)
+            failure = REXML::XPath.first(node, "failure")
+            error_el = REXML::XPath.first(node, "error")
+            skipped = REXML::XPath.first(node, "skipped")
+
+            if failure
+              [:failed, failure.attributes["message"] || failure.text&.strip]
+            elsif error_el
+              [:errored, error_el.attributes["message"] || error_el.text&.strip]
+            elsif skipped
+              [:skipped, nil]
+            else
+              [:passed, nil]
+            end
+          end
+          # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+
+          def classname_to_file(classname)
+            "#{classname.gsub("::", "/").gsub(".", "/")}.rb"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/parsers/minitest_json.rb
+++ b/lib/wild/analyzers/test_flakes/parsers/minitest_json.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Parsers
+        class MinitestJson < Base
+          STATUS_MAP = {
+            "pass" => :passed, "passed" => :passed, "ok" => :passed,
+            "fail" => :failed, "failed" => :failed, "failure" => :failed,
+            "error" => :errored, "errored" => :errored,
+            "skip" => :skipped, "skipped" => :skipped
+          }.freeze
+
+          def parse(input, run_id: nil, timestamp: nil)
+            require_non_empty!(input)
+
+            data = parse_json!(input)
+            validate_minitest_format!(data)
+
+            extract_tests(data, coerce_run_id(run_id), timestamp || default_timestamp)
+          end
+
+          private
+
+          def parse_json!(input)
+            JSON.parse(input)
+          rescue JSON::ParserError => e
+            raise ParseError, "Invalid JSON: #{e.message}"
+          end
+
+          def validate_minitest_format!(data)
+            raise ParseError, "Minitest JSON must be a Hash" unless data.is_a?(Hash)
+
+            return if data.key?("tests") || data.key?("results")
+
+            raise ParseError, 'Minitest JSON must contain "tests" or "results" key'
+          end
+
+          def extract_tests(data, run_id, timestamp)
+            tests = data["tests"] || data["results"] || []
+            raise ParseError, '"tests" must be an Array' unless tests.is_a?(Array)
+
+            tests.filter_map do |test|
+              next unless test.is_a?(Hash)
+
+              build_result_from_test(test, run_id, timestamp)
+            rescue ArgumentError
+              nil
+            end
+          end
+
+          def build_result_from_test(test, run_id, timestamp)
+            identity = extract_identity(test)
+            build_result(
+              identity: identity,
+              status: map_status(test["result"] || test["status"] || "pass"),
+              run_id: run_id,
+              timestamp: timestamp,
+              duration_ms: test["time"] ? (test["time"].to_f * 1000).round(3) : nil,
+              error_message: (test["failure"] || test["error"] || test["message"])&.to_s
+            )
+          end
+
+          def extract_identity(test)
+            name = test["name"] || test["test_name"] || "unknown"
+            klass = test["class"] || test["suite"] || ""
+            file_path = test["file"] || klass_to_file(klass)
+            build_identity(
+              file_path: file_path.empty? ? "unknown" : file_path,
+              test_name: name,
+              context: klass
+            )
+          end
+
+          def map_status(raw)
+            STATUS_MAP.fetch(raw.to_s.downcase, :errored)
+          end
+
+          def klass_to_file(klass)
+            return "" if klass.to_s.empty?
+
+            "#{klass.gsub("::", "/")}_test.rb"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/parsers/rspec_json.rb
+++ b/lib/wild/analyzers/test_flakes/parsers/rspec_json.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Parsers
+        class RspecJson < Base
+          def parse(input, run_id: nil, timestamp: nil)
+            require_non_empty!(input)
+
+            data = parse_json!(input)
+            validate_rspec_format!(data)
+
+            resolved_run_id = run_id || data.dig("summary", "run_id") || coerce_run_id(nil)
+            resolved_ts = timestamp || default_timestamp
+
+            extract_examples(data, resolved_run_id, resolved_ts)
+          end
+
+          private
+
+          def parse_json!(input)
+            JSON.parse(input)
+          rescue JSON::ParserError => e
+            raise ParseError, "Invalid JSON: #{e.message}"
+          end
+
+          def validate_rspec_format!(data)
+            raise ParseError, "RSpec JSON must be a Hash" unless data.is_a?(Hash)
+            raise ParseError, 'RSpec JSON must contain an "examples" key' unless data.key?("examples")
+            raise ParseError, '"examples" must be an Array' unless data["examples"].is_a?(Array)
+          end
+
+          def extract_examples(data, run_id, timestamp)
+            data["examples"].filter_map do |example|
+              next unless example.is_a?(Hash)
+
+              build_result_from_example(example, run_id, timestamp)
+            rescue ArgumentError
+              nil
+            end
+          end
+
+          def build_result_from_example(example, run_id, timestamp)
+            identity = extract_example_identity(example)
+            build_result(
+              identity: identity,
+              status: map_status(example["status"]),
+              run_id: run_id,
+              timestamp: timestamp,
+              duration_ms: example["run_time"] ? (example["run_time"].to_f * 1000).round(3) : nil,
+              error_message: extract_error_message(example),
+              metadata: { seed: data_seed(example) }.compact
+            )
+          end
+
+          def extract_example_identity(example)
+            file_path = example["file_path"] || example["location"]&.split(":")&.first || "unknown"
+            description = example["full_description"] || example["description"] || "unknown"
+            build_identity(
+              file_path: file_path,
+              test_name: extract_test_name(description),
+              context: extract_context(description)
+            )
+          end
+
+          def extract_context(full_description)
+            parts = full_description.split
+            return "" if parts.size <= 1
+
+            parts[0..-2].join(" ")
+          end
+
+          def extract_test_name(full_description)
+            parts = full_description.split
+            parts.size > 1 ? parts.last : full_description
+          end
+
+          def map_status(status)
+            case status
+            when "passed" then :passed
+            when "failed" then :failed
+            when "pending" then :pending
+            else :errored
+            end
+          end
+
+          def extract_error_message(example)
+            exception = example["exception"]
+            return nil unless exception.is_a?(Hash)
+
+            exception["message"]
+          end
+
+          def data_seed(example)
+            example["seed"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/triage/engine.rb
+++ b/lib/wild/analyzers/test_flakes/triage/engine.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Triage
+        class Engine
+          def initialize(scorer: nil, remediation: nil, history_store: nil)
+            @scorer = scorer || SeverityScorer.new
+            @remediation = remediation || Remediation.new
+            @history_store = history_store
+          end
+
+          def triage(flake_records)
+            raise ArgumentError, "flake_records must be an Array" unless flake_records.is_a?(Array)
+
+            entries = flake_records.filter_map { |record| build_entry(record) }
+            entries.sort_by { |e| -e.severity_score }
+          end
+
+          private
+
+          def build_entry(record)
+            trend = fetch_trend(record)
+            score = @scorer.score(record, trend: trend)
+            severity = @scorer.severity_from_score(score)
+            suggestions = @remediation.all_suggestions_for(record.root_causes)
+
+            Models::TriageEntry.new(
+              flake_record: record,
+              severity: severity,
+              severity_score: score,
+              remediations: suggestions,
+              trend: trend
+            )
+          end
+
+          def fetch_trend(record)
+            return :stable unless @history_store
+
+            @history_store.trend_for(record.test_identity) || :stable
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/triage/remediation.rb
+++ b/lib/wild/analyzers/test_flakes/triage/remediation.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Triage
+        class Remediation
+          SUGGESTIONS = {
+            timing_dependent: [
+              "Add explicit waits or retry logic for time-sensitive operations",
+              "Increase timeout thresholds for slow CI environments",
+              "Mock time-dependent code with deterministic values",
+              "Extract timing logic into configurable delays"
+            ],
+            order_dependent: [
+              "Add database cleanup between tests (use DatabaseCleaner or equivalent)",
+              "Ensure each test sets up its own state independently",
+              "Run suspect test in isolation to confirm order dependency",
+              "Add explicit teardown for any global/class-level state"
+            ],
+            shared_state: [
+              "Add before/after hooks to reset shared state",
+              "Use let/let! instead of instance variables in RSpec",
+              "Check for class-level memoization or caching",
+              "Audit any constants or class variables modified during tests"
+            ],
+            external_dependency: [
+              "Mock or stub external HTTP/API calls",
+              "Use VCR or WebMock to record and replay network interactions",
+              "Add retry logic with exponential backoff for flaky dependencies",
+              "Add integration test tag and exclude from standard runs"
+            ],
+            random_seed: [
+              "Pin the random seed for deterministic test runs during debugging",
+              "Remove or isolate tests that depend on random data ordering",
+              "Use factory patterns that produce deterministic data",
+              "Check for shuffle! or sample calls on shared arrays"
+            ],
+            resource_contention: [
+              "Run tests with lower parallelism to reduce resource pressure",
+              "Check for port conflicts in parallel test runs",
+              "Add file locking for tests that write to shared files",
+              "Isolate resource-intensive tests into a separate suite"
+            ],
+            timezone_locale: [
+              'Set explicit timezone in test setup (e.g., Time.zone = "UTC")',
+              "Use travel_to or freeze_time helpers for time-sensitive assertions",
+              "Avoid locale-dependent string formatting in assertions",
+              'Set ENV["TZ"] = "UTC" in test configuration'
+            ],
+            unknown: [
+              "Run test in isolation to determine if it fails alone",
+              "Add verbose logging to capture state at failure time",
+              "Review recent changes to this test file",
+              "Check for any recently introduced global state changes"
+            ]
+          }.freeze
+
+          def suggestions_for(root_causes)
+            return SUGGESTIONS[:unknown] if root_causes.blank?
+
+            primary = root_causes.max_by(&:confidence)
+            SUGGESTIONS.fetch(primary.category, SUGGESTIONS[:unknown])
+          end
+
+          def all_suggestions_for(root_causes)
+            return SUGGESTIONS[:unknown] if root_causes.blank?
+
+            root_causes
+              .sort_by { |rc| -rc.confidence }
+              .flat_map { |rc| SUGGESTIONS.fetch(rc.category, []) }
+              .uniq
+              .first(6)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/analyzers/test_flakes/triage/severity_scorer.rb
+++ b/lib/wild/analyzers/test_flakes/triage/severity_scorer.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module Triage
+        class SeverityScorer
+          def initialize(weights: nil)
+            config = Wild.config.analyzers.test_flakes
+            @weights = weights || config.severity_weights
+          end
+
+          def score(flake_record, trend: :stable)
+            components = weighted_components(flake_record, trend)
+            raw = components.sum / total_weight
+            [raw, 1.0].min.round(4)
+          end
+
+          def severity_from_score(score)
+            case score
+            when 0.75..Float::INFINITY then :critical
+            when 0.5...0.75 then :high
+            when 0.25...0.5 then :medium
+            else :low
+            end
+          end
+
+          TREND_MULTIPLIERS = { worsening: 0.9, stable: 0.5, improving: 0.1 }.freeze
+
+          private
+
+          def weighted_components(flake_record, trend)
+            [
+              flake_record.flake_rate * @weights[:flake_rate],
+              failure_count_score(flake_record.failure_count) * @weights[:failure_count],
+              trend_multiplier(trend) * @weights[:trend],
+              top_confidence(flake_record) * @weights[:confidence]
+            ]
+          end
+
+          def failure_count_score(count)
+            [Math.log10([count, 1].max) / 3.0, 1.0].min
+          end
+
+          def trend_multiplier(trend)
+            TREND_MULTIPLIERS.fetch(trend, 0.5)
+          end
+
+          def top_confidence(flake_record)
+            return 0.0 if flake_record.root_causes.empty?
+
+            flake_record.root_causes.map(&:confidence).max || 0.0
+          end
+
+          def total_weight
+            @weights.values.sum.to_f
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/configuration.rb
+++ b/lib/wild/configuration.rb
@@ -187,9 +187,36 @@ module Wild
         end
       end
 
+      TEST_FLAKES_DEFAULT_SEVERITY_WEIGHTS = {
+        flake_rate: 1.0, failure_count: 1.0, trend: 1.0, confidence: 1.0
+      }.freeze
+
+      # TestFlakes carries the flake-detection knobs the old
+      # wild-test-flake-forensics gem exposed plus the `classifier_corpus_path`
+      # placeholder from PR-B (consumed by the F3 golden-corpus work). Defaults
+      # preserved verbatim; the gem's per-setter validation + freeze! machinery
+      # is NOT carried over (Wild's no-freeze configuration design).
+      #
       # `classifier_corpus_path: nil` means "engineer must supply"; runtime
       # raises Wild::Analyzers::Error if the classifier is invoked without a path.
-      TestFlakes = Struct.new(:classifier_corpus_path, keyword_init: true)
+      TestFlakes = Struct.new(
+        :classifier_corpus_path,
+        :minimum_runs,
+        :flake_rate_threshold,
+        :max_history_entries,
+        :severity_weights,
+        keyword_init: true
+      ) do
+        def initialize(**kwargs)
+          super(
+            classifier_corpus_path: kwargs.fetch(:classifier_corpus_path, nil),
+            minimum_runs: kwargs.fetch(:minimum_runs, 3),
+            flake_rate_threshold: kwargs.fetch(:flake_rate_threshold, 0.1),
+            max_history_entries: kwargs.fetch(:max_history_entries, 10_000),
+            severity_weights: kwargs.fetch(:severity_weights, TEST_FLAKES_DEFAULT_SEVERITY_WEIGHTS.dup)
+          )
+        end
+      end
 
       attr_reader :permission, :test_flakes
 

--- a/lib/wild/error.rb
+++ b/lib/wild/error.rb
@@ -130,6 +130,20 @@ module Wild
       # Raised when report export fails.
       class ExportError < Error; end
     end
+
+    # TestFlakes sub-namespace errors (from wild-test-flake-forensics).
+    module TestFlakes
+      class Error < Wild::Analyzers::Error; end
+
+      # Raised when a test-result report (rspec/junit/minitest) cannot be parsed.
+      class ParseError < Error; end
+
+      # Raised when flake detection fails on otherwise-valid input.
+      class DetectionError < Error; end
+
+      # Raised when report export fails.
+      class ExportError < Error; end
+    end
   end
 
   module Skillops

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,11 +45,13 @@ require "wild"
 require_relative "support/wild_hooks/hook_fixtures"
 require_relative "support/wild_skillops/fixtures"
 require_relative "support/wild_analyzers_permission/fixtures"
+require_relative "support/wild_analyzers_test_flakes/fixtures"
 
 RSpec.configure do |config|
   config.include Wild::Hooks::TestSupport::HookFixtures
   config.include Wild::Skillops::TestSupport::Fixtures
   config.include Wild::Analyzers::Permission::TestSupport::Fixtures
+  config.include Wild::Analyzers::TestFlakes::TestSupport::Fixtures
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/support/wild_analyzers_test_flakes/fixtures.rb
+++ b/spec/support/wild_analyzers_test_flakes/fixtures.rb
@@ -1,0 +1,286 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ModuleLength, Metrics/MethodLength, Metrics/ParameterLists, Metrics/AbcSize
+
+require "time"
+
+module Wild
+  module Analyzers
+    module TestFlakes
+      module TestSupport
+        module Fixtures
+          BASE_TIMESTAMP = Time.utc(2024, 3, 1, 10, 0, 0)
+
+          module_function
+
+          def rspec_json_string(examples: nil, run_id: "run-001")
+            examples ||= default_rspec_examples
+            JSON.generate({
+                            "version" => "3.13.0",
+                            "seed" => 12_345,
+                            "summary" => {
+                              "run_id" => run_id,
+                              "duration" => 2.5,
+                              "example_count" => examples.size,
+                              "failure_count" => examples.count { |e| e["status"] == "failed" }
+                            },
+                            "examples" => examples
+                          })
+          end
+
+          def default_rspec_examples
+            [
+              {
+                "id" => "./spec/models/user_spec.rb[1:1]",
+                "description" => "is valid",
+                "full_description" => "User is valid",
+                "status" => "passed",
+                "file_path" => "./spec/models/user_spec.rb",
+                "line_number" => 5,
+                "run_time" => 0.012
+              },
+              {
+                "id" => "./spec/models/user_spec.rb[1:2]",
+                "description" => "validates email",
+                "full_description" => "User validates email",
+                "status" => "failed",
+                "file_path" => "./spec/models/user_spec.rb",
+                "line_number" => 10,
+                "run_time" => 0.023,
+                "exception" => {
+                  "class" => "RSpec::Expectations::ExpectationNotMetError",
+                  "message" => "expected true but got false"
+                }
+              },
+              {
+                "id" => "./spec/services/payment_spec.rb[1:1]",
+                "description" => "processes payment",
+                "full_description" => "PaymentService processes payment",
+                "status" => "passed",
+                "file_path" => "./spec/services/payment_spec.rb",
+                "line_number" => 8,
+                "run_time" => 1.5
+              }
+            ]
+          end
+
+          def junit_xml_string(test_cases: nil)
+            cases = test_cases || default_junit_cases
+            xml_parts = ['<?xml version="1.0" encoding="UTF-8"?>',
+                         '<testsuite name="RSpec" tests="3" failures="1" errors="0" time="2.5">']
+            cases.each { |c| xml_parts << c }
+            xml_parts << "</testsuite>"
+            xml_parts.join("\n")
+          end
+
+          def default_junit_cases
+            [
+              '<testcase classname="User" name="is valid" time="0.012"/>',
+              '<testcase classname="User" name="validates email" time="0.023">' \
+              '<failure message="expected true but got false">Stack trace here</failure>' \
+              "</testcase>",
+              '<testcase classname="PaymentService" name="processes payment" time="1.5"/>'
+            ]
+          end
+
+          def minitest_json_string(tests: nil)
+            tests ||= default_minitest_tests
+            JSON.generate({ "tests" => tests })
+          end
+
+          def default_minitest_tests
+            [
+              {
+                "name" => "test_is_valid",
+                "class" => "UserTest",
+                "file" => "test/models/user_test.rb",
+                "result" => "pass",
+                "time" => 0.012
+              },
+              {
+                "name" => "test_validates_email",
+                "class" => "UserTest",
+                "file" => "test/models/user_test.rb",
+                "result" => "fail",
+                "time" => 0.023,
+                "failure" => 'Expected: true\n  Actual: false'
+              },
+              {
+                "name" => "test_payment_processing",
+                "class" => "PaymentServiceTest",
+                "file" => "test/services/payment_service_test.rb",
+                "result" => "pass",
+                "time" => 1.5
+              }
+            ]
+          end
+
+          def make_identity(file_path: "spec/models/user_spec.rb", test_name: "is valid", context: "User")
+            Wild::Analyzers::TestFlakes::Models::TestIdentity.new(
+              file_path: file_path,
+              test_name: test_name,
+              context: context
+            )
+          end
+
+          def make_result(identity: nil, status: :passed, run_id: "run-001",
+                          timestamp: nil, duration_ms: 10.0, error_message: nil, metadata: {})
+            identity ||= make_identity
+            Wild::Analyzers::TestFlakes::Models::TestResult.new(
+              test_identity: identity,
+              status: status,
+              run_id: run_id,
+              timestamp: timestamp || BASE_TIMESTAMP,
+              duration_ms: duration_ms,
+              error_message: error_message,
+              metadata: metadata
+            )
+          end
+
+          def flaky_results(identity: nil, pass_count: 3, fail_count: 2, base_run: "run")
+            id = identity || make_identity
+            results = []
+
+            pass_count.times do |i|
+              results << make_result(
+                identity: id,
+                status: :passed,
+                run_id: "#{base_run}-#{i + 1}",
+                timestamp: BASE_TIMESTAMP + (i * 3600),
+                duration_ms: 10.0 + (i * 2)
+              )
+            end
+
+            fail_count.times do |i|
+              results << make_result(
+                identity: id,
+                status: :failed,
+                run_id: "#{base_run}-#{pass_count + i + 1}",
+                timestamp: BASE_TIMESTAMP + ((pass_count + i) * 3600),
+                duration_ms: 25.0 + (i * 5),
+                error_message: "Expected: true, got: false"
+              )
+            end
+
+            results
+          end
+
+          def flake_record_with(root_causes: [], flake_rate_numerator: 2, total: 5, identity: nil)
+            id = identity || make_identity
+            results = []
+            (total - flake_rate_numerator).times do |i|
+              results << make_result(identity: id, status: :passed, run_id: "run-#{i + 1}",
+                                     timestamp: BASE_TIMESTAMP + (i * 3600))
+            end
+            flake_rate_numerator.times do |i|
+              results << make_result(identity: id, status: :failed,
+                                     run_id: "run-#{total - flake_rate_numerator + i + 1}",
+                                     timestamp: BASE_TIMESTAMP + ((total - flake_rate_numerator + i) * 3600))
+            end
+
+            Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+              test_identity: id,
+              results: results,
+              root_causes: root_causes
+            )
+          end
+
+          def results_with_high_variance(identity: nil)
+            id = identity || make_identity
+            durations = [5.0, 10.0, 15.0, 200.0, 250.0, 8.0, 300.0]
+            statuses = %i[passed passed passed failed failed passed failed]
+
+            durations.each_with_index.map do |d, i|
+              make_result(
+                identity: id,
+                status: statuses[i],
+                run_id: "run-#{i + 1}",
+                timestamp: BASE_TIMESTAMP + (i * 3600),
+                duration_ms: d
+              )
+            end
+          end
+
+          def results_with_external_errors(identity: nil)
+            id = identity || make_identity
+            [
+              make_result(identity: id, status: :passed, run_id: "run-1", timestamp: BASE_TIMESTAMP),
+              make_result(identity: id, status: :passed, run_id: "run-2",
+                          timestamp: BASE_TIMESTAMP + 3600),
+              make_result(identity: id, status: :failed, run_id: "run-3",
+                          timestamp: BASE_TIMESTAMP + 7200,
+                          error_message: "connection refused: database connection timeout"),
+              make_result(identity: id, status: :failed, run_id: "run-4",
+                          timestamp: BASE_TIMESTAMP + 10_800,
+                          error_message: "Net::ReadTimeout: HTTP request timed out"),
+              make_result(identity: id, status: :passed, run_id: "run-5",
+                          timestamp: BASE_TIMESTAMP + 14_400)
+            ]
+          end
+
+          def results_with_timezone_errors(identity: nil)
+            id = identity || make_identity
+            [
+              make_result(identity: id, status: :passed, run_id: "run-1", timestamp: BASE_TIMESTAMP),
+              make_result(identity: id, status: :passed, run_id: "run-2",
+                          timestamp: BASE_TIMESTAMP + 3600),
+              make_result(identity: id, status: :failed, run_id: "run-3",
+                          timestamp: BASE_TIMESTAMP + 7200,
+                          error_message: "ActiveSupport::TimeZone UTC offset mismatch"),
+              make_result(identity: id, status: :passed, run_id: "run-4",
+                          timestamp: BASE_TIMESTAMP + 10_800)
+            ]
+          end
+
+          def results_with_seeds(identity: nil)
+            id = identity || make_identity
+            [
+              make_result(identity: id, status: :passed, run_id: "run-1", timestamp: BASE_TIMESTAMP,
+                          metadata: { seed: 12_345 }),
+              make_result(identity: id, status: :passed, run_id: "run-2",
+                          timestamp: BASE_TIMESTAMP + 3600, metadata: { seed: 12_345 }),
+              make_result(identity: id, status: :failed, run_id: "run-3",
+                          timestamp: BASE_TIMESTAMP + 7200, metadata: { seed: 99_999 }),
+              make_result(identity: id, status: :failed, run_id: "run-4",
+                          timestamp: BASE_TIMESTAMP + 10_800, metadata: { seed: 99_999 }),
+              make_result(identity: id, status: :passed, run_id: "run-5",
+                          timestamp: BASE_TIMESTAMP + 14_400, metadata: { seed: 12_345 })
+            ]
+          end
+
+          def multiple_flake_records(count: 3, base_file: "spec/models")
+            count.times.map do |i|
+              id = make_identity(
+                file_path: "#{base_file}/model_#{i}_spec.rb",
+                test_name: "test_behavior_#{i}",
+                context: "Model#{i}"
+              )
+              flake_record_with(identity: id, flake_rate_numerator: 2, total: 5)
+            end
+          end
+
+          def triage_entry(severity: :high, score: 0.65, record: nil)
+            r = record || flake_record_with(
+              root_causes: [
+                Wild::Analyzers::TestFlakes::Models::RootCause.new(
+                  category: :timing_dependent,
+                  confidence: 0.75,
+                  description: "High variance"
+                )
+              ]
+            )
+            Wild::Analyzers::TestFlakes::Models::TriageEntry.new(
+              flake_record: r,
+              severity: severity,
+              severity_score: score,
+              remediations: ["Add retry logic", "Mock time"],
+              trend: :stable
+            )
+          end
+        end
+      end
+    end
+  end
+end
+
+# rubocop:enable Metrics/ModuleLength, Metrics/MethodLength, Metrics/ParameterLists, Metrics/AbcSize

--- a/spec/wild/analyzers/test_flakes/adversarial/edge_cases_spec.rb
+++ b/spec/wild/analyzers/test_flakes/adversarial/edge_cases_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass, Layout/LineLength
+
+RSpec.describe "Edge case handling" do
+  let(:detector) { Wild::Analyzers::TestFlakes::Detection::FlakeDetector.new(minimum_runs: 2) }
+  let(:analyzer) { Wild::Analyzers::TestFlakes::Analysis::RootCauseAnalyzer.new }
+  let(:engine) { Wild::Analyzers::TestFlakes::Triage::Engine.new }
+
+  describe "special characters in test names" do
+    let(:special_chars) do
+      [
+        "test with 'single quotes'",
+        'test with "double quotes"',
+        "test with <brackets>",
+        "test with & ampersand",
+        "test with\nnewline",
+        "test with | pipe",
+        "test with `backtick`"
+      ]
+    end
+
+    it "handles special characters in test names without raising" do
+      results = special_chars.flat_map do |name|
+        id = make_identity(test_name: name)
+        [
+          make_result(identity: id, status: :passed, run_id: "run-1",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP),
+          make_result(identity: id, status: :failed, run_id: "run-2",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + 3600)
+        ]
+      end
+      expect { detector.detect(results) }.not_to raise_error
+    end
+
+    it "handles special characters in markdown export" do
+      id = make_identity(test_name: "test with | pipe and `backtick`")
+      record = flake_record_with(identity: id)
+      entry = Wild::Analyzers::TestFlakes::Models::TriageEntry.new(
+        flake_record: record, severity: :high, severity_score: 0.6
+      )
+      exporter = Wild::Analyzers::TestFlakes::Export::MarkdownExporter.new
+      expect { exporter.export([entry]) }.not_to raise_error
+    end
+  end
+
+  describe "large result sets" do
+    it "handles 1000 results without error" do
+      results = 100.times.flat_map do |test_i|
+        id = make_identity(test_name: "test_#{test_i}", file_path: "spec/test_#{test_i}_spec.rb")
+        10.times.map do |run_i|
+          status = test_i % 3 == 0 && run_i % 3 == 0 ? :failed : :passed
+          make_result(
+            identity: id,
+            status: status,
+            run_id: "run-#{run_i + 1}",
+            timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (run_i * 3600)
+          )
+        end
+      end
+
+      expect { detector.detect(results) }.not_to raise_error
+    end
+
+    it "processes 1000 results in a reasonable time" do
+      results = 200.times.flat_map do |i|
+        id = make_identity(test_name: "test_#{i}")
+        5.times.map do |j|
+          make_result(
+            identity: id,
+            status: i % 4 == 0 ? :failed : :passed,
+            run_id: "run-#{j + 1}",
+            timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (j * 3600)
+          )
+        end
+      end
+
+      start = Time.now.utc
+      detector.detect(results)
+      elapsed = Time.now.utc - start
+      expect(elapsed).to be < 5.0
+    end
+  end
+
+  describe "boundary conditions" do
+    it "handles exactly minimum_runs results" do
+      id = make_identity
+      results = [
+        make_result(identity: id, status: :passed, run_id: "run-1",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP),
+        make_result(identity: id, status: :passed, run_id: "run-2",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + 3600),
+        make_result(identity: id, status: :failed, run_id: "run-3",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + 7200)
+      ]
+      records = detector.detect(results)
+      expect(records.size).to eq(1)
+    end
+
+    it "handles zero duration gracefully" do
+      id = make_identity
+      results = [
+        make_result(identity: id, status: :passed, run_id: "run-1",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP, duration_ms: 0.0),
+        make_result(identity: id, status: :failed, run_id: "run-2",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + 3600, duration_ms: 0.0)
+      ]
+      record = Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(test_identity: id, results: results)
+      expect { record.duration_variance }.not_to raise_error
+    end
+
+    it "handles nil duration_ms gracefully" do
+      id = make_identity
+      results = [
+        make_result(identity: id, status: :passed, run_id: "run-1",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP, duration_ms: nil),
+        make_result(identity: id, status: :failed, run_id: "run-2",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + 3600, duration_ms: nil)
+      ]
+      record = Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(test_identity: id, results: results)
+      expect(record.duration_variance).to eq(0.0)
+    end
+
+    it "handles empty error_message gracefully" do
+      id = make_identity
+      results = flaky_results(identity: id, pass_count: 3, fail_count: 2)
+      record = Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(test_identity: id, results: results)
+      expect { analyzer.analyze([record]) }.not_to raise_error
+    end
+
+    it "handles all-skipped results in detection" do
+      id = make_identity
+      results = 5.times.map do |i|
+        make_result(identity: id, status: :skipped, run_id: "run-#{i + 1}",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (i * 3600))
+      end
+      records = detector.detect(results)
+      expect(records).to be_empty
+    end
+  end
+
+  describe "adversarial filenames" do
+    it "handles path traversal-like file names safely" do
+      id = make_identity(file_path: "../../../etc/passwd")
+      results = flaky_results(identity: id)
+      expect { detector.detect(results) }.not_to raise_error
+    end
+
+    it "handles very long file paths" do
+      long_path = "spec/#{"a" * 500}_spec.rb"
+      id = make_identity(file_path: long_path)
+      results = flaky_results(identity: id)
+      expect { detector.detect(results) }.not_to raise_error
+    end
+
+    it "handles unicode in test names" do
+      id = make_identity(test_name: "validates UTF-8 input: こんにちは")
+      results = flaky_results(identity: id)
+      expect { detector.detect(results) }.not_to raise_error
+    end
+  end
+
+  describe "History store under pressure" do
+    let(:store) { Wild::Analyzers::TestFlakes::History::Store.new(max_entries: 5) }
+
+    it "does not grow beyond max_entries" do
+      10.times do |i|
+        id = make_identity(test_name: "test_#{i}")
+        record = flake_record_with(identity: id)
+        store.record(record)
+      end
+      expect(store.size).to be <= 5
+    end
+  end
+
+  # The old gem's Configuration class had a freeze!/frozen? lifecycle. Wild's
+  # typed Struct dropped it (no-freeze configuration design). The freeze spec
+  # is deleted rather than rewritten — F3 (no vanity tests of absent behavior).
+end
+
+# rubocop:enable RSpec/DescribeClass, Layout/LineLength

--- a/spec/wild/analyzers/test_flakes/adversarial/malformed_input_spec.rb
+++ b/spec/wild/analyzers/test_flakes/adversarial/malformed_input_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+
+RSpec.describe "Malformed input handling" do
+  let(:rspec_parser) { Wild::Analyzers::TestFlakes::Parsers::RspecJson.new }
+  let(:junit_parser) { Wild::Analyzers::TestFlakes::Parsers::JunitXml.new }
+  let(:minitest_parser) { Wild::Analyzers::TestFlakes::Parsers::MinitestJson.new }
+  let(:opts) { { run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP } }
+
+  describe "RSpec JSON parser" do
+    it "raises ParseError for nil input" do
+      expect { rspec_parser.parse(nil, **opts) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for empty string" do
+      expect { rspec_parser.parse("", **opts) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for whitespace only" do
+      expect { rspec_parser.parse("   ", **opts) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for truncated JSON" do
+      expect { rspec_parser.parse('{"examples": [{"id": "foo"', **opts) }
+        .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for JSON array at root" do
+      expect { rspec_parser.parse("[]", **opts) }
+        .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for JSON object without examples" do
+      expect { rspec_parser.parse('{"summary": {}}', **opts) }
+        .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "skips non-hash example entries gracefully" do
+      json = JSON.generate({ "examples" => ["string_entry", nil, 42, { "status" => "passed",
+                                                                       "file_path" => "./spec/foo.rb",
+                                                                       "full_description" => "Foo bar" }] })
+      results = rspec_parser.parse(json, **opts)
+      expect(results).to be_an(Array)
+    end
+  end
+
+  describe "JUnit XML parser" do
+    it "raises ParseError for nil input" do
+      expect { junit_parser.parse(nil, **opts) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for empty string" do
+      expect { junit_parser.parse("", **opts) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for XML with wrong root element" do
+      xml = "<html><body>not junit</body></html>"
+      expect { junit_parser.parse(xml, **opts) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for completely malformed XML" do
+      expect { junit_parser.parse("<<<<", **opts) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "handles empty testsuite gracefully" do
+      xml = '<testsuite name="empty"></testsuite>'
+      results = junit_parser.parse(xml, **opts)
+      expect(results).to eq([])
+    end
+  end
+
+  describe "Minitest JSON parser" do
+    it "raises ParseError for nil input" do
+      expect { minitest_parser.parse(nil, **opts) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for JSON without tests or results key" do
+      expect { minitest_parser.parse('{"count": 5}', **opts) }
+        .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "raises ParseError for non-JSON input" do
+      expect { minitest_parser.parse("Run options: --seed 12345", **opts) }
+        .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+    end
+
+    it "skips non-hash test entries" do
+      json = JSON.generate({ "tests" => [nil, "bad", { "name" => "test_foo",
+                                                       "class" => "FooTest", "result" => "pass" }] })
+      results = minitest_parser.parse(json, **opts)
+      expect(results).to be_an(Array)
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass

--- a/spec/wild/analyzers/test_flakes/analysis/root_cause_analyzer_spec.rb
+++ b/spec/wild/analyzers/test_flakes/analysis/root_cause_analyzer_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Analysis::RootCauseAnalyzer do
+  subject(:analyzer) { described_class.new }
+
+  describe "#analyze" do
+    context "with high timing variance records" do
+      let(:identity) { make_identity }
+      let(:record) do
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+          test_identity: identity,
+          results: results_with_high_variance(identity: identity)
+        )
+      end
+
+      it "assigns root causes" do
+        analyzed = analyzer.analyze([record])
+        expect(analyzed.first.root_causes).not_to be_empty
+      end
+
+      it "returns FlakeRecord objects" do
+        analyzed = analyzer.analyze([record])
+        expect(analyzed).to all(be_a(Wild::Analyzers::TestFlakes::Models::FlakeRecord))
+      end
+    end
+
+    context "with external dependency signals" do
+      let(:identity) { make_identity }
+      let(:record) do
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+          test_identity: identity,
+          results: results_with_external_errors(identity: identity)
+        )
+      end
+
+      it "identifies external_dependency as a root cause" do
+        analyzed = analyzer.analyze([record])
+        categories = analyzed.first.root_causes.map(&:category)
+        expect(categories).to include(:external_dependency)
+      end
+    end
+
+    context "with timezone signals" do
+      let(:identity) { make_identity }
+      let(:record) do
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+          test_identity: identity,
+          results: results_with_timezone_errors(identity: identity)
+        )
+      end
+
+      it "identifies timezone_locale as a root cause" do
+        analyzed = analyzer.analyze([record])
+        categories = analyzed.first.root_causes.map(&:category)
+        expect(categories).to include(:timezone_locale)
+      end
+    end
+
+    context "with no discernible signals" do
+      let(:record) { flake_record_with }
+
+      it "assigns unknown root cause when no signals match" do
+        analyzed = analyzer.analyze([record])
+        expect(analyzed.first.root_causes).not_to be_empty
+      end
+    end
+
+    context "with multiple records in same file" do
+      let(:records) { multiple_flake_records(count: 3, base_file: "spec/shared") }
+
+      it "processes all records" do
+        analyzed = analyzer.analyze(records)
+        expect(analyzed.size).to eq(3)
+      end
+    end
+
+    context "with invalid input" do
+      it "raises ArgumentError" do
+        expect { analyzer.analyze("bad") }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with empty input" do
+      it "returns empty array" do
+        expect(analyzer.analyze([])).to eq([])
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/analysis/signal_extractors_spec.rb
+++ b/spec/wild/analyzers/test_flakes/analysis/signal_extractors_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Analysis::SignalExtractors do
+  subject(:extractor) { extractor_class.new }
+
+  let(:extractor_class) do
+    Class.new do
+      include Wild::Analyzers::TestFlakes::Analysis::SignalExtractors
+    end
+  end
+  let(:base_record) { flake_record_with }
+
+  describe "#timing_signal" do
+    context "with high duration variance" do
+      let(:record) do
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+          test_identity: make_identity,
+          results: results_with_high_variance
+        )
+      end
+
+      it "returns a score > 0" do
+        expect(extractor.timing_signal(record)).to be > 0
+      end
+    end
+
+    context "with uniform durations" do
+      let(:record) do
+        id = make_identity
+        results = 5.times.map do |i|
+          make_result(identity: id, duration_ms: 10.0, run_id: "run-#{i + 1}",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (i * 3600))
+        end
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(test_identity: id, results: results)
+      end
+
+      it "returns 0.0" do
+        expect(extractor.timing_signal(record)).to eq(0.0)
+      end
+    end
+  end
+
+  describe "#shared_state_signal" do
+    it "returns 0.0 when no other flakes in same file" do
+      record = flake_record_with
+      score = extractor.shared_state_signal(record, [record])
+      expect(score).to eq(0.0)
+    end
+
+    it "returns a positive score when multiple flakes share a file" do
+      id1 = make_identity(file_path: "spec/shared/foo_spec.rb", test_name: "test_a")
+      id2 = make_identity(file_path: "spec/shared/foo_spec.rb", test_name: "test_b")
+      id3 = make_identity(file_path: "spec/shared/foo_spec.rb", test_name: "test_c")
+
+      records = [id1, id2, id3].map { |id| flake_record_with(identity: id) }
+      score = extractor.shared_state_signal(records[0], records)
+      expect(score).to be > 0
+    end
+  end
+
+  describe "#external_dependency_signal" do
+    context "with network error messages" do
+      let(:record) do
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+          test_identity: make_identity,
+          results: results_with_external_errors
+        )
+      end
+
+      it "returns a high score" do
+        expect(extractor.external_dependency_signal(record)).to be > 0.5
+      end
+    end
+
+    context "with no error messages" do
+      it "returns 0.0" do
+        expect(extractor.external_dependency_signal(base_record)).to eq(0.0)
+      end
+    end
+  end
+
+  describe "#random_seed_signal" do
+    context "with different seeds correlating to different outcomes" do
+      let(:record) do
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+          test_identity: make_identity,
+          results: results_with_seeds
+        )
+      end
+
+      it "returns a high score" do
+        expect(extractor.random_seed_signal(record)).to be > 0.5
+      end
+    end
+
+    context "with no seed metadata" do
+      it "returns low or zero score" do
+        expect(extractor.random_seed_signal(base_record)).to be <= 0.5
+      end
+    end
+  end
+
+  describe "#timezone_locale_signal" do
+    context "with timezone error messages" do
+      let(:record) do
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+          test_identity: make_identity,
+          results: results_with_timezone_errors
+        )
+      end
+
+      it "returns a positive score" do
+        expect(extractor.timezone_locale_signal(record)).to be > 0
+      end
+    end
+
+    context "with no timezone-related errors" do
+      it "returns 0.0" do
+        expect(extractor.timezone_locale_signal(base_record)).to eq(0.0)
+      end
+    end
+  end
+
+  describe "#resource_contention_signal" do
+    it "returns 0.0 with empty results_by_run" do
+      expect(extractor.resource_contention_signal(base_record, {})).to eq(0.0)
+    end
+
+    context "when failures cluster with many other failures in same run" do
+      let(:contention_record) do
+        id = make_identity
+        results = flaky_results(identity: id, pass_count: 3, fail_count: 3)
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(test_identity: id, results: results)
+      end
+
+      let(:contention_run_map) do
+        contention_record.results.select(&:failed?).to_h do |r|
+          [r.run_id, 10.times.map do |i|
+            make_result(identity: make_identity(test_name: "other_test_#{i}"),
+                        status: :failed, run_id: r.run_id,
+                        timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+          end]
+        end
+      end
+
+      it "returns a positive score" do
+        score = extractor.resource_contention_signal(contention_record, contention_run_map)
+        expect(score).to be > 0
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/detection/comparator_spec.rb
+++ b/spec/wild/analyzers/test_flakes/detection/comparator_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Detection::Comparator do
+  subject(:comparator) { described_class.new }
+
+  describe "#group_by_identity" do
+    let(:identity_a) { make_identity(test_name: "test_a") }
+    let(:identity_b) { make_identity(test_name: "test_b") }
+
+    it "groups results by identity key" do
+      results = [
+        make_result(identity: identity_a, run_id: "run-1"),
+        make_result(identity: identity_a, run_id: "run-2"),
+        make_result(identity: identity_b, run_id: "run-1")
+      ]
+      grouped = comparator.group_by_identity(results)
+      expect(grouped.keys.size).to eq(2)
+      expect(grouped[identity_a.key].size).to eq(2)
+    end
+
+    it "raises DetectionError for non-Array input" do
+      expect { comparator.group_by_identity("bad") }
+        .to raise_error(Wild::Analyzers::TestFlakes::DetectionError)
+    end
+
+    it "skips non-TestResult objects" do
+      results = [make_result, "not a result", nil]
+      grouped = comparator.group_by_identity(results)
+      expect(grouped.size).to eq(1)
+    end
+  end
+
+  describe "#both_outcomes?" do
+    it "returns true when results have both pass and fail" do
+      results = [make_result(status: :passed), make_result(status: :failed)]
+      expect(comparator.both_outcomes?(results)).to be(true)
+    end
+
+    it "returns false when only passes" do
+      results = [make_result(status: :passed), make_result(status: :passed)]
+      expect(comparator.both_outcomes?(results)).to be(false)
+    end
+
+    it "returns false when only failures" do
+      results = [make_result(status: :failed), make_result(status: :failed)]
+      expect(comparator.both_outcomes?(results)).to be(false)
+    end
+
+    it "treats :errored as failed" do
+      results = [make_result(status: :passed), make_result(status: :errored)]
+      expect(comparator.both_outcomes?(results)).to be(true)
+    end
+  end
+
+  describe "#flake_rate" do
+    it "calculates proportion of failures" do
+      results = [
+        make_result(status: :passed),
+        make_result(status: :passed),
+        make_result(status: :failed)
+      ]
+      expect(comparator.flake_rate(results)).to be_within(0.001).of(1.0 / 3.0)
+    end
+
+    it "returns 0.0 for empty array" do
+      expect(comparator.flake_rate([])).to eq(0.0)
+    end
+  end
+
+  describe "#run_ids_with_failures" do
+    it "returns IDs from failed runs only" do
+      results = [
+        make_result(status: :passed, run_id: "run-1"),
+        make_result(status: :failed, run_id: "run-2"),
+        make_result(status: :failed, run_id: "run-2")
+      ]
+      expect(comparator.run_ids_with_failures(results)).to eq(["run-2"])
+    end
+  end
+
+  describe "#run_ids_with_passes" do
+    it "returns IDs from passing runs only" do
+      results = [
+        make_result(status: :passed, run_id: "run-1"),
+        make_result(status: :failed, run_id: "run-2")
+      ]
+      expect(comparator.run_ids_with_passes(results)).to eq(["run-1"])
+    end
+  end
+
+  describe ".group_by_identity class method" do
+    it "delegates to instance method" do
+      results = [make_result]
+      grouped = described_class.group_by_identity(results)
+      expect(grouped).to be_a(Hash)
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/detection/flake_detector_spec.rb
+++ b/spec/wild/analyzers/test_flakes/detection/flake_detector_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# rubocop:disable Layout/LineLength
+
+RSpec.describe Wild::Analyzers::TestFlakes::Detection::FlakeDetector do
+  subject(:detector) { described_class.new }
+
+  describe "#detect" do
+    context "with a clearly flaky test" do
+      let(:identity) { make_identity }
+      let(:results) { flaky_results(identity: identity, pass_count: 4, fail_count: 2) }
+
+      it "returns a FlakeRecord for the flaky test" do
+        records = detector.detect(results)
+        expect(records.size).to eq(1)
+        expect(records.first).to be_a(Wild::Analyzers::TestFlakes::Models::FlakeRecord)
+      end
+
+      it "captures the correct identity" do
+        records = detector.detect(results)
+        expect(records.first.test_identity).to eq(identity)
+      end
+
+      it "captures all results in the record" do
+        records = detector.detect(results)
+        expect(records.first.total_runs).to eq(6)
+      end
+    end
+
+    context "with a stable passing test" do
+      let(:identity) { make_identity }
+      let(:results) do
+        5.times.map do |i|
+          make_result(identity: identity, status: :passed, run_id: "run-#{i + 1}",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (i * 3600))
+        end
+      end
+
+      it "returns no flake records" do
+        records = detector.detect(results)
+        expect(records).to be_empty
+      end
+    end
+
+    context "with insufficient runs" do
+      let(:identity) { make_identity }
+      let(:results) do
+        [
+          make_result(identity: identity, status: :passed, run_id: "run-1",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP),
+          make_result(identity: identity, status: :failed, run_id: "run-2",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + 3600)
+        ]
+      end
+
+      it "ignores tests with fewer than minimum_runs" do
+        records = detector.detect(results)
+        expect(records).to be_empty
+      end
+    end
+
+    context "with flake_rate below threshold" do
+      let(:identity) { make_identity }
+
+      it "ignores tests below the flake threshold" do
+        # 1 failure out of 20 runs = 5%, below default 10% threshold
+        results = 19.times.map do |i|
+          make_result(identity: identity, status: :passed, run_id: "run-#{i + 1}",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (i * 3600))
+        end
+        results << make_result(identity: identity, status: :failed, run_id: "run-20",
+                               timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (19 * 3600))
+
+        records = detector.detect(results)
+        expect(records).to be_empty
+      end
+    end
+
+    context "with multiple tests" do
+      let(:stable_identity) { make_identity(test_name: "test_a") }
+      let(:flaky_identity_b) { make_identity(test_name: "test_b") }
+      let(:flaky_identity_c) { make_identity(test_name: "test_c") }
+
+      it "detects only the flaky tests" do
+        stable_results = 5.times.map do |i|
+          make_result(identity: stable_identity, status: :passed, run_id: "run-#{i + 1}",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (i * 3600))
+        end
+        flaky_b = flaky_results(identity: flaky_identity_b, pass_count: 3, fail_count: 2)
+        flaky_c = flaky_results(identity: flaky_identity_c, pass_count: 2, fail_count: 3)
+
+        records = detector.detect(stable_results + flaky_b + flaky_c)
+        expect(records.map { |r| r.test_identity.test_name }).to contain_exactly("test_b", "test_c")
+      end
+    end
+
+    context "with custom thresholds" do
+      let(:detector) { described_class.new(minimum_runs: 2, flake_rate_threshold: 0.4) }
+      let(:identity) { make_identity }
+
+      it "uses configured minimum_runs" do
+        results = [
+          make_result(identity: identity, status: :passed, run_id: "run-1",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP),
+          make_result(identity: identity, status: :failed, run_id: "run-2",
+                      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + 3600)
+        ]
+        records = detector.detect(results)
+        expect(records.size).to eq(1)
+      end
+    end
+
+    context "with empty input" do
+      it "returns empty array" do
+        expect(detector.detect([])).to eq([])
+      end
+    end
+
+    context "with invalid input" do
+      it "raises DetectionError" do
+        expect { detector.detect("bad") }
+          .to raise_error(Wild::Analyzers::TestFlakes::DetectionError)
+      end
+    end
+  end
+end
+
+# rubocop:enable Layout/LineLength

--- a/spec/wild/analyzers/test_flakes/export/json_exporter_spec.rb
+++ b/spec/wild/analyzers/test_flakes/export/json_exporter_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Export::JsonExporter do
+  subject(:exporter) { described_class.new }
+
+  let(:entries) { [triage_entry, triage_entry(severity: :medium, score: 0.35)] }
+
+  describe "#export" do
+    it "returns a String" do
+      result = exporter.export(entries)
+      expect(result).to be_a(String)
+    end
+
+    it "produces valid JSON" do
+      result = exporter.export(entries)
+      expect { JSON.parse(result) }.not_to raise_error
+    end
+
+    it "includes a metadata section" do
+      parsed = JSON.parse(exporter.export(entries))
+      expect(parsed).to have_key("metadata")
+    end
+
+    it "includes a summary section" do
+      parsed = JSON.parse(exporter.export(entries))
+      expect(parsed).to have_key("summary")
+    end
+
+    it "includes a flakes array" do
+      parsed = JSON.parse(exporter.export(entries))
+      expect(parsed["flakes"]).to be_an(Array)
+      expect(parsed["flakes"].size).to eq(2)
+    end
+
+    it "includes correct summary counts" do
+      parsed = JSON.parse(exporter.export(entries))
+      expect(parsed["summary"]["total"]).to eq(2)
+    end
+
+    it "includes avg_flake_rate in summary" do
+      parsed = JSON.parse(exporter.export(entries))
+      expect(parsed["summary"]["avg_flake_rate"]).to be_a(Numeric)
+    end
+
+    it "accepts custom metadata" do
+      result = exporter.export(entries, metadata: { "ci_build" => "build-123" })
+      parsed = JSON.parse(result)
+      expect(parsed["metadata"]["ci_build"]).to eq("build-123")
+    end
+
+    context "with empty entries" do
+      it "returns valid JSON with zero counts" do
+        parsed = JSON.parse(exporter.export([]))
+        expect(parsed["summary"]["total"]).to eq(0)
+      end
+    end
+
+    context "with invalid input" do
+      it "raises ExportError" do
+        expect { exporter.export("bad") }.to raise_error(Wild::Analyzers::TestFlakes::ExportError)
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/export/markdown_exporter_spec.rb
+++ b/spec/wild/analyzers/test_flakes/export/markdown_exporter_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Export::MarkdownExporter do
+  subject(:exporter) { described_class.new }
+
+  let(:entries) { [triage_entry, triage_entry(severity: :critical, score: 0.9)] }
+
+  describe "#export" do
+    it "returns a String" do
+      result = exporter.export(entries)
+      expect(result).to be_a(String)
+    end
+
+    it "includes the default title" do
+      expect(exporter.export(entries)).to include("Flaky Test Triage Report")
+    end
+
+    it "accepts a custom title" do
+      result = exporter.export(entries, title: "Custom Report")
+      expect(result).to include("Custom Report")
+    end
+
+    it "includes a summary section" do
+      expect(exporter.export(entries)).to include("## Summary")
+    end
+
+    it "includes severity table" do
+      result = exporter.export(entries)
+      expect(result).to include("Critical")
+      expect(result).to include("High")
+    end
+
+    it "includes a flaky tests section" do
+      expect(exporter.export(entries)).to include("## Flaky Tests")
+    end
+
+    it "includes each test name" do
+      result = exporter.export(entries)
+      entries.each do |entry|
+        expect(result).to include(entry.test_identity.test_name)
+      end
+    end
+
+    it "includes flake rate" do
+      expect(exporter.export(entries)).to include("Flake Rate")
+    end
+
+    it "includes remediation suggestions" do
+      expect(exporter.export(entries)).to include("Suggested Remediations")
+    end
+
+    context "with empty entries" do
+      it "includes no flakes message" do
+        result = exporter.export([])
+        expect(result).to include("No flaky tests detected")
+      end
+    end
+
+    context "with invalid input" do
+      it "raises ExportError" do
+        expect { exporter.export("bad") }.to raise_error(Wild::Analyzers::TestFlakes::ExportError)
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/export/summary_exporter_spec.rb
+++ b/spec/wild/analyzers/test_flakes/export/summary_exporter_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Export::SummaryExporter do
+  subject(:exporter) { described_class.new }
+
+  let(:entries) { [triage_entry(severity: :critical, score: 0.9), triage_entry] }
+
+  describe "#export" do
+    it "returns a String ending in newline" do
+      result = exporter.export(entries)
+      expect(result).to be_a(String)
+      expect(result).to end_with("\n")
+    end
+
+    it "includes FLAKE REPORT header" do
+      expect(exporter.export(entries)).to include("FLAKE REPORT")
+    end
+
+    it "includes total count" do
+      expect(exporter.export(entries)).to include("2 flaky test")
+    end
+
+    it "includes severity labels" do
+      result = exporter.export(entries)
+      expect(result).to include("[CRITICAL]").or include("[HIGH]")
+    end
+
+    it "includes test names" do
+      result = exporter.export(entries)
+      entries.each do |entry|
+        # Name may be truncated; check prefix
+        name_prefix = entry.test_identity.test_name[0, 20]
+        expect(result).to include(name_prefix)
+      end
+    end
+
+    it "includes flake percentage" do
+      expect(exporter.export(entries)).to match(/\d+\.\d+%/)
+    end
+
+    context "with empty entries" do
+      it "returns a no-flakes message" do
+        result = exporter.export([])
+        expect(result).to include("No flaky tests detected")
+      end
+    end
+
+    context "with invalid input" do
+      it "raises ExportError" do
+        expect { exporter.export("bad") }.to raise_error(Wild::Analyzers::TestFlakes::ExportError)
+      end
+    end
+
+    context "with very long test name" do
+      let(:entries) do
+        long_name = "a" * 100
+        id = make_identity(test_name: long_name)
+        record = flake_record_with(identity: id)
+        [
+          Wild::Analyzers::TestFlakes::Models::TriageEntry.new(
+            flake_record: record,
+            severity: :high,
+            severity_score: 0.6
+          )
+        ]
+      end
+
+      it "truncates long names" do
+        result = exporter.export(entries)
+        lines = result.split("\n").reject { |l| l.start_with?("FLAKE") }
+        expect(lines.first.length).to be <= 120
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/history/store_spec.rb
+++ b/spec/wild/analyzers/test_flakes/history/store_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::History::Store do
+  subject(:store) { described_class.new }
+
+  let(:record) { flake_record_with }
+  let(:identity) { record.test_identity }
+
+  describe "#record" do
+    it "stores a flake record" do
+      store.record(record)
+      expect(store.size).to eq(1)
+    end
+
+    it "returns the stored record" do
+      result = store.record(record)
+      expect(result).to be_a(Wild::Analyzers::TestFlakes::Models::FlakeRecord)
+    end
+
+    it "merges when recording the same identity twice" do
+      store.record(record)
+      store.record(record)
+      expect(store.size).to eq(1)
+    end
+
+    it "tracks different identities separately" do
+      id2 = make_identity(test_name: "different test")
+      record2 = flake_record_with(identity: id2)
+      store.record(record)
+      store.record(record2)
+      expect(store.size).to eq(2)
+    end
+  end
+
+  describe "#fetch" do
+    it "returns nil when identity not found" do
+      expect(store.fetch(identity)).to be_nil
+    end
+
+    it "returns the stored record for a known identity" do
+      store.record(record)
+      fetched = store.fetch(identity)
+      expect(fetched.test_identity).to eq(identity)
+    end
+  end
+
+  describe "#all" do
+    it "returns all stored records" do
+      store.record(record)
+      expect(store.all.size).to eq(1)
+    end
+
+    it "returns an array copy" do
+      store.record(record)
+      all1 = store.all
+      all2 = store.all
+      expect(all1).not_to equal(all2)
+    end
+  end
+
+  describe "#trend_for" do
+    it "returns :stable for unknown identity" do
+      expect(store.trend_for(identity)).to eq(:stable)
+    end
+
+    it "returns :stable with single snapshot" do
+      store.record(record)
+      expect(store.trend_for(identity)).to eq(:stable)
+    end
+  end
+
+  describe "#size" do
+    it "returns 0 initially" do
+      expect(store.size).to eq(0)
+    end
+  end
+
+  describe "#clear!" do
+    it "empties the store" do
+      store.record(record)
+      store.clear!
+      expect(store.size).to eq(0)
+    end
+  end
+
+  describe "max_entries limit" do
+    let(:store) { described_class.new(max_entries: 2) }
+
+    it "enforces the max_entries limit" do
+      3.times do |i|
+        id = make_identity(test_name: "test_#{i}")
+        r = flake_record_with(identity: id)
+        store.record(r)
+      end
+      expect(store.size).to be <= 2
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/history/trend_analyzer_spec.rb
+++ b/spec/wild/analyzers/test_flakes/history/trend_analyzer_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::History::TrendAnalyzer do
+  subject(:analyzer) { described_class.new }
+
+  describe "#trend_from_rates" do
+    context "when flake rate is increasing" do
+      it "returns :worsening" do
+        rates = [0.1, 0.15, 0.2, 0.25, 0.3, 0.35]
+        expect(analyzer.trend_from_rates(rates)).to eq(:worsening)
+      end
+    end
+
+    context "when flake rate is decreasing" do
+      it "returns :improving" do
+        rates = [0.4, 0.35, 0.3, 0.2, 0.1, 0.05]
+        expect(analyzer.trend_from_rates(rates)).to eq(:improving)
+      end
+    end
+
+    context "when flake rate is stable" do
+      it "returns :stable" do
+        rates = [0.2, 0.21, 0.19, 0.20, 0.21, 0.20]
+        expect(analyzer.trend_from_rates(rates)).to eq(:stable)
+      end
+    end
+
+    context "with fewer than 2 rates" do
+      it "returns :stable for single rate" do
+        expect(analyzer.trend_from_rates([0.5])).to eq(:stable)
+      end
+
+      it "returns :stable for empty array" do
+        expect(analyzer.trend_from_rates([])).to eq(:stable)
+      end
+    end
+  end
+
+  describe "#trend" do
+    let(:base_time) { Time.utc(2024, 1, 1) }
+
+    context "with worsening snapshots" do
+      let(:snapshots) do
+        rates = [0.1, 0.15, 0.2, 0.3, 0.4, 0.5]
+        rates.each_with_index.map do |rate, i|
+          { rate: rate, at: base_time + (i * 3600) }
+        end
+      end
+
+      it "returns :worsening" do
+        expect(analyzer.trend(snapshots)).to eq(:worsening)
+      end
+    end
+
+    context "with improving snapshots" do
+      let(:snapshots) do
+        rates = [0.5, 0.4, 0.3, 0.2, 0.1, 0.05]
+        rates.each_with_index.map do |rate, i|
+          { rate: rate, at: base_time + (i * 3600) }
+        end
+      end
+
+      it "returns :improving" do
+        expect(analyzer.trend(snapshots)).to eq(:improving)
+      end
+    end
+
+    context "with only one snapshot" do
+      it "returns :stable" do
+        expect(analyzer.trend([{ rate: 0.3, at: base_time }])).to eq(:stable)
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/integration/full_pipeline_spec.rb
+++ b/spec/wild/analyzers/test_flakes/integration/full_pipeline_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleMemoizedHelpers, Layout/LineLength
+
+RSpec.describe "Full pipeline integration" do
+  let(:detector) { Wild::Analyzers::TestFlakes::Detection::FlakeDetector.new(minimum_runs: 3) }
+  let(:analyzer) { Wild::Analyzers::TestFlakes::Analysis::RootCauseAnalyzer.new }
+  let(:engine) { Wild::Analyzers::TestFlakes::Triage::Engine.new }
+  let(:json_exporter) { Wild::Analyzers::TestFlakes::Export::JsonExporter.new }
+  let(:markdown_exporter) { Wild::Analyzers::TestFlakes::Export::MarkdownExporter.new }
+  let(:summary_exporter) { Wild::Analyzers::TestFlakes::Export::SummaryExporter.new }
+
+  context "with flaky test results" do
+    let(:user_profile_identity) { make_identity(test_name: "loads user profile", context: "UserController") }
+    let(:email_identity) { make_identity(test_name: "sends confirmation email", context: "MailerJob") }
+    let(:stable_identity) { make_identity(test_name: "returns 200 OK", context: "HealthCheck") }
+
+    let(:results) do
+      flaky1 = flaky_results(identity: user_profile_identity, pass_count: 4, fail_count: 2)
+      flaky2 = results_with_external_errors(identity: email_identity)
+      stable = 5.times.map do |i|
+        make_result(identity: stable_identity, status: :passed, run_id: "run-#{i + 1}",
+                    timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (i * 3600))
+      end
+      flaky1 + flaky2 + stable
+    end
+
+    it "completes the full pipeline without errors" do
+      flakes = detector.detect(results)
+      analyzed = analyzer.analyze(flakes, all_results: results)
+      entries = engine.triage(analyzed)
+
+      expect(entries).not_to be_empty
+      expect(entries).to all(be_a(Wild::Analyzers::TestFlakes::Models::TriageEntry))
+    end
+
+    it "identifies the flaky tests but not the stable test" do
+      flakes = detector.detect(results)
+      test_names = flakes.map { |f| f.test_identity.test_name }
+
+      expect(test_names).to include("loads user profile")
+      expect(test_names).not_to include("returns 200 OK")
+    end
+
+    it "produces valid JSON output" do
+      flakes = detector.detect(results)
+      analyzed = analyzer.analyze(flakes, all_results: results)
+      entries = engine.triage(analyzed)
+      json_output = json_exporter.export(entries)
+
+      parsed = JSON.parse(json_output)
+      expect(parsed["summary"]["total"]).to be >= 1
+    end
+
+    it "produces non-empty markdown output" do
+      flakes = detector.detect(results)
+      analyzed = analyzer.analyze(flakes, all_results: results)
+      entries = engine.triage(analyzed)
+      md_output = markdown_exporter.export(entries)
+
+      expect(md_output).to include("## Summary")
+      expect(md_output).to include("## Flaky Tests")
+    end
+
+    it "produces summary output" do
+      flakes = detector.detect(results)
+      analyzed = analyzer.analyze(flakes, all_results: results)
+      entries = engine.triage(analyzed)
+      summary = summary_exporter.export(entries)
+
+      expect(summary).to include("FLAKE REPORT")
+    end
+
+    it "assigns root causes to detected flakes" do
+      flakes = detector.detect(results)
+      analyzed = analyzer.analyze(flakes, all_results: results)
+
+      analyzed.each do |record|
+        expect(record.root_causes).not_to be_empty
+      end
+    end
+  end
+
+  context "with no flaky results" do
+    let(:results) do
+      5.times.flat_map do |i|
+        [
+          make_result(identity: make_identity(test_name: "test_a"), status: :passed,
+                      run_id: "run-#{i + 1}", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (i * 3600)),
+          make_result(identity: make_identity(test_name: "test_b"), status: :passed,
+                      run_id: "run-#{i + 1}", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + (i * 3600))
+        ]
+      end
+    end
+
+    it "produces no triage entries" do
+      flakes = detector.detect(results)
+      entries = engine.triage(flakes)
+      expect(entries).to be_empty
+    end
+
+    it "exports cleanly with empty entries" do
+      entries = []
+      expect(json_exporter.export(entries)).to include('"total":0')
+      expect(summary_exporter.export(entries)).to include("No flaky tests detected")
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleMemoizedHelpers, Layout/LineLength

--- a/spec/wild/analyzers/test_flakes/integration/multi_format_spec.rb
+++ b/spec/wild/analyzers/test_flakes/integration/multi_format_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+
+RSpec.describe "Multi-format parsing integration" do
+  let(:detector) { Wild::Analyzers::TestFlakes::Detection::FlakeDetector.new(minimum_runs: 2) }
+  let(:run_id) { "run-multi-001" }
+  let(:timestamp) { Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP }
+
+  def parse_rspec(examples:)
+    Wild::Analyzers::TestFlakes::Parsers::RspecJson.parse(
+      rspec_json_string(examples: examples),
+      run_id: run_id,
+      timestamp: timestamp
+    )
+  end
+
+  def parse_junit(cases:)
+    Wild::Analyzers::TestFlakes::Parsers::JunitXml.parse(
+      junit_xml_string(test_cases: cases),
+      run_id: run_id,
+      timestamp: timestamp
+    )
+  end
+
+  def parse_minitest(tests:)
+    Wild::Analyzers::TestFlakes::Parsers::MinitestJson.parse(
+      minitest_json_string(tests: tests),
+      run_id: run_id,
+      timestamp: timestamp
+    )
+  end
+
+  describe "parsing different formats and combining results" do
+    it "parses RSpec JSON results successfully" do
+      results = parse_rspec(examples: default_rspec_examples)
+      expect(results).to all(be_a(Wild::Analyzers::TestFlakes::Models::TestResult))
+    end
+
+    it "parses JUnit XML results successfully" do
+      results = parse_junit(cases: default_junit_cases)
+      expect(results).to all(be_a(Wild::Analyzers::TestFlakes::Models::TestResult))
+    end
+
+    it "parses minitest JSON results successfully" do
+      results = parse_minitest(tests: default_minitest_tests)
+      expect(results).to all(be_a(Wild::Analyzers::TestFlakes::Models::TestResult))
+    end
+
+    it "combined results from multiple formats can be fed to detector" do
+      rspec_results = parse_rspec(examples: default_rspec_examples)
+      junit_results = parse_junit(cases: default_junit_cases)
+      minitest_results = parse_minitest(tests: default_minitest_tests)
+
+      all_results = rspec_results + junit_results + minitest_results
+      expect { detector.detect(all_results) }.not_to raise_error
+    end
+  end
+
+  describe "simulating multi-run flake detection across formats" do
+    let(:passing_example) do
+      [{ "full_description" => "UserModel is valid", "status" => "passed",
+         "file_path" => "./spec/models/user_spec.rb", "run_time" => 0.01 }]
+    end
+
+    let(:failing_example) do
+      [{ "full_description" => "UserModel is valid", "status" => "failed",
+         "file_path" => "./spec/models/user_spec.rb", "run_time" => 0.01,
+         "exception" => { "message" => "expected true got false" } }]
+    end
+
+    it "detects flake from two RSpec runs with different outcomes" do
+      run1 = Wild::Analyzers::TestFlakes::Parsers::RspecJson.parse(
+        rspec_json_string(examples: passing_example),
+        run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP
+      )
+      run2 = Wild::Analyzers::TestFlakes::Parsers::RspecJson.parse(
+        rspec_json_string(examples: failing_example),
+        run_id: "run-002", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP + 3600
+      )
+      records = detector.detect(run1 + run2)
+      expect(records.size).to eq(1)
+      expect(records.first.flake_rate).to eq(0.5)
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass

--- a/spec/wild/analyzers/test_flakes/models/flake_record_spec.rb
+++ b/spec/wild/analyzers/test_flakes/models/flake_record_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Models::FlakeRecord do
+  subject(:record) do
+    described_class.new(test_identity: identity, results: results)
+  end
+
+  let(:identity) { make_identity }
+  let(:results) { flaky_results(identity: identity, pass_count: 3, fail_count: 2) }
+
+  describe "#initialize" do
+    it "stores identity and results" do
+      expect(record.test_identity).to eq(identity)
+      expect(record.results.size).to eq(5)
+    end
+
+    it "raises ArgumentError for invalid identity" do
+      expect { described_class.new(test_identity: "bad", results: results) }
+        .to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for non-Array results" do
+      expect { described_class.new(test_identity: identity, results: "bad") }
+        .to raise_error(ArgumentError)
+    end
+
+    it "sets first_seen from earliest result" do
+      expect(record.first_seen).not_to be_nil
+    end
+
+    it "sets last_seen from latest result" do
+      expect(record.last_seen).not_to be_nil
+    end
+  end
+
+  describe "#flake_rate" do
+    it "calculates failure percentage" do
+      expect(record.flake_rate).to eq(0.4)
+    end
+
+    it "returns 0.0 for empty results" do
+      empty = described_class.new(test_identity: identity, results: [])
+      expect(empty.flake_rate).to eq(0.0)
+    end
+  end
+
+  describe "#total_runs" do
+    it "returns the count of all results" do
+      expect(record.total_runs).to eq(5)
+    end
+  end
+
+  describe "#failure_count" do
+    it "returns the count of failures" do
+      expect(record.failure_count).to eq(2)
+    end
+  end
+
+  describe "#pass_count" do
+    it "returns the count of passes" do
+      expect(record.pass_count).to eq(3)
+    end
+  end
+
+  describe "#run_ids" do
+    it "returns unique run IDs" do
+      expect(record.run_ids.size).to eq(5)
+    end
+  end
+
+  describe "#durations" do
+    it "returns non-nil duration values" do
+      expect(record.durations).to all(be_a(Numeric))
+    end
+  end
+
+  describe "#duration_variance" do
+    it "returns 0.0 for single result" do
+      single = described_class.new(
+        test_identity: identity,
+        results: [make_result(identity: identity, duration_ms: 10.0)]
+      )
+      expect(single.duration_variance).to eq(0.0)
+    end
+
+    it "computes variance for multiple results" do
+      high_var = described_class.new(
+        test_identity: identity,
+        results: results_with_high_variance(identity: identity)
+      )
+      expect(high_var.duration_variance).to be > 0
+    end
+  end
+
+  describe "#primary_root_cause" do
+    it "returns nil when no root causes" do
+      expect(record.primary_root_cause).to be_nil
+    end
+
+    it "returns the cause with highest confidence" do
+      cause1 = Wild::Analyzers::TestFlakes::Models::RootCause.new(category: :unknown, confidence: 0.3)
+      cause2 = Wild::Analyzers::TestFlakes::Models::RootCause.new(category: :timing_dependent, confidence: 0.8)
+      r = described_class.new(test_identity: identity, results: results, root_causes: [cause1, cause2])
+      expect(r.primary_root_cause.category).to eq(:timing_dependent)
+    end
+  end
+
+  describe "#to_h" do
+    it "includes expected keys" do
+      h = record.to_h
+      expect(h).to include(:test_identity, :flake_rate, :total_runs, :failure_count)
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/models/root_cause_spec.rb
+++ b/spec/wild/analyzers/test_flakes/models/root_cause_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Models::RootCause do
+  subject(:cause) do
+    described_class.new(
+      category: :timing_dependent,
+      confidence: 0.75,
+      evidence: ["High duration variance"],
+      description: "Test is timing sensitive"
+    )
+  end
+
+  describe "#initialize" do
+    it "stores all attributes" do
+      expect(cause.category).to eq(:timing_dependent)
+      expect(cause.confidence).to eq(0.75)
+      expect(cause.evidence).to eq(["High duration variance"])
+      expect(cause.description).to eq("Test is timing sensitive")
+    end
+
+    it "accepts all valid categories" do
+      described_class::CATEGORIES.each do |cat|
+        expect { described_class.new(category: cat, confidence: 0.5) }.not_to raise_error
+      end
+    end
+
+    it "raises ArgumentError for invalid category" do
+      expect { described_class.new(category: :bogus, confidence: 0.5) }
+        .to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for confidence > 1" do
+      expect { described_class.new(category: :unknown, confidence: 1.5) }
+        .to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for negative confidence" do
+      expect { described_class.new(category: :unknown, confidence: -0.1) }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#high_confidence?" do
+    it "returns true when confidence >= 0.7" do
+      expect(cause.high_confidence?).to be(true)
+    end
+
+    it "returns false when confidence < 0.7" do
+      low = described_class.new(category: :unknown, confidence: 0.5)
+      expect(low.high_confidence?).to be(false)
+    end
+  end
+
+  describe "#medium_confidence?" do
+    it "returns true for confidence in [0.4, 0.7)" do
+      med = described_class.new(category: :unknown, confidence: 0.5)
+      expect(med.medium_confidence?).to be(true)
+    end
+  end
+
+  describe "#low_confidence?" do
+    it "returns true for confidence < 0.4" do
+      low = described_class.new(category: :unknown, confidence: 0.3)
+      expect(low.low_confidence?).to be(true)
+    end
+  end
+
+  describe "#to_h" do
+    it "includes all fields" do
+      h = cause.to_h
+      expect(h[:category]).to eq(:timing_dependent)
+      expect(h[:confidence]).to eq(0.75)
+      expect(h[:evidence]).to eq(["High duration variance"])
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/models/test_identity_spec.rb
+++ b/spec/wild/analyzers/test_flakes/models/test_identity_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Models::TestIdentity do
+  subject(:identity) do
+    described_class.new(file_path: "spec/models/user_spec.rb", test_name: "is valid", context: "User")
+  end
+
+  describe "#initialize" do
+    it "stores file_path, test_name, and context" do
+      expect(identity.file_path).to eq("spec/models/user_spec.rb")
+      expect(identity.test_name).to eq("is valid")
+      expect(identity.context).to eq("User")
+    end
+
+    it "allows nil context" do
+      id = described_class.new(file_path: "spec/foo.rb", test_name: "does something")
+      expect(id.context).to eq("")
+    end
+
+    it "raises ArgumentError for empty file_path" do
+      expect { described_class.new(file_path: "", test_name: "test") }
+        .to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for empty test_name" do
+      expect { described_class.new(file_path: "spec/foo.rb", test_name: "") }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#key" do
+    it "returns a composite string" do
+      expect(identity.key).to eq("spec/models/user_spec.rb::User::is valid")
+    end
+
+    it "is consistent across calls" do
+      key_a = identity.key
+      key_b = identity.key
+      expect(key_a).to eq(key_b)
+    end
+  end
+
+  describe "#==" do
+    it "is equal to an identity with same attributes" do
+      other = described_class.new(
+        file_path: "spec/models/user_spec.rb",
+        test_name: "is valid",
+        context: "User"
+      )
+      expect(identity).to eq(other)
+    end
+
+    it "is not equal with different test_name" do
+      other = described_class.new(
+        file_path: "spec/models/user_spec.rb",
+        test_name: "is invalid",
+        context: "User"
+      )
+      expect(identity).not_to eq(other)
+    end
+  end
+
+  describe "#hash" do
+    it "returns consistent hash for same identity" do
+      other = described_class.new(
+        file_path: "spec/models/user_spec.rb",
+        test_name: "is valid",
+        context: "User"
+      )
+      expect(identity.hash).to eq(other.hash)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation" do
+      expect(identity.to_h).to eq(
+        file_path: "spec/models/user_spec.rb",
+        test_name: "is valid",
+        context: "User"
+      )
+    end
+  end
+
+  describe "#to_s" do
+    it "includes file, context, and test name" do
+      expect(identity.to_s).to include("spec/models/user_spec.rb")
+      expect(identity.to_s).to include("User")
+      expect(identity.to_s).to include("is valid")
+    end
+
+    it "omits context segment when context is empty" do
+      id = described_class.new(file_path: "spec/foo.rb", test_name: "does something")
+      expect(id.to_s).to eq("spec/foo.rb — does something")
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/models/test_result_spec.rb
+++ b/spec/wild/analyzers/test_flakes/models/test_result_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Models::TestResult do
+  subject(:result) do
+    described_class.new(
+      test_identity: identity,
+      status: :passed,
+      run_id: "run-001",
+      timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP,
+      duration_ms: 12.5
+    )
+  end
+
+  let(:identity) { make_identity }
+
+  describe "#initialize" do
+    it "stores all attributes" do
+      expect(result.test_identity).to eq(identity)
+      expect(result.status).to eq(:passed)
+      expect(result.run_id).to eq("run-001")
+      expect(result.duration_ms).to eq(12.5)
+    end
+
+    it "defaults metadata to empty hash" do
+      expect(result.metadata).to eq({})
+    end
+
+    it "raises ArgumentError for invalid identity" do
+      expect do
+        described_class.new(
+          test_identity: "not an identity",
+          status: :passed,
+          run_id: "run-001",
+          timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP
+        )
+      end.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for invalid status" do
+      expect do
+        described_class.new(
+          test_identity: identity,
+          status: :bogus,
+          run_id: "run-001",
+          timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP
+        )
+      end.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for empty run_id" do
+      expect do
+        described_class.new(
+          test_identity: identity,
+          status: :passed,
+          run_id: "",
+          timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP
+        )
+      end.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for nil timestamp" do
+      expect do
+        described_class.new(
+          test_identity: identity,
+          status: :passed,
+          run_id: "run-001",
+          timestamp: nil
+        )
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#passed?" do
+    it "returns true when status is :passed" do
+      expect(result.passed?).to be(true)
+    end
+
+    it "returns false when status is :failed" do
+      r = make_result(status: :failed)
+      expect(r.passed?).to be(false)
+    end
+  end
+
+  describe "#failed?" do
+    it "returns true when status is :failed" do
+      r = make_result(status: :failed)
+      expect(r.failed?).to be(true)
+    end
+
+    it "returns true when status is :errored" do
+      r = make_result(status: :errored)
+      expect(r.failed?).to be(true)
+    end
+
+    it "returns false when status is :passed" do
+      expect(result.failed?).to be(false)
+    end
+  end
+
+  describe "#skipped?" do
+    it "returns true for :skipped" do
+      r = make_result(status: :skipped)
+      expect(r.skipped?).to be(true)
+    end
+
+    it "returns true for :pending" do
+      r = make_result(status: :pending)
+      expect(r.skipped?).to be(true)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash with all fields" do
+      h = result.to_h
+      expect(h[:status]).to eq(:passed)
+      expect(h[:run_id]).to eq("run-001")
+      expect(h[:duration_ms]).to eq(12.5)
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/models/triage_entry_spec.rb
+++ b/spec/wild/analyzers/test_flakes/models/triage_entry_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Models::TriageEntry do
+  subject(:entry) do
+    described_class.new(
+      flake_record: record,
+      severity: :high,
+      severity_score: 0.65,
+      remediations: ["Add retry logic"],
+      trend: :worsening
+    )
+  end
+
+  let(:record) { flake_record_with }
+
+  describe "#initialize" do
+    it "stores all attributes" do
+      expect(entry.severity).to eq(:high)
+      expect(entry.severity_score).to eq(0.65)
+      expect(entry.trend).to eq(:worsening)
+      expect(entry.remediations).to eq(["Add retry logic"])
+    end
+
+    it "raises ArgumentError for invalid flake_record" do
+      expect do
+        described_class.new(
+          flake_record: "bad",
+          severity: :high,
+          severity_score: 0.5
+        )
+      end.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for invalid severity" do
+      expect do
+        described_class.new(
+          flake_record: record,
+          severity: :catastrophic,
+          severity_score: 0.5
+        )
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#test_identity" do
+    it "delegates to flake_record" do
+      expect(entry.test_identity).to eq(record.test_identity)
+    end
+  end
+
+  describe "#critical?" do
+    it "returns false for high severity" do
+      expect(entry.critical?).to be(false)
+    end
+
+    it "returns true for critical severity" do
+      e = described_class.new(flake_record: record, severity: :critical, severity_score: 0.9)
+      expect(e.critical?).to be(true)
+    end
+  end
+
+  describe "#high?" do
+    it "returns true for high severity" do
+      expect(entry.high?).to be(true)
+    end
+  end
+
+  describe "#to_h" do
+    it "includes severity and flake data" do
+      h = entry.to_h
+      expect(h[:severity]).to eq(:high)
+      expect(h[:trend]).to eq(:worsening)
+      expect(h[:remediations]).to eq(["Add retry logic"])
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/parsers/junit_xml_spec.rb
+++ b/spec/wild/analyzers/test_flakes/parsers/junit_xml_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Parsers::JunitXml do
+  subject(:parser) { described_class.new }
+
+  describe "#parse" do
+    context "with valid JUnit XML" do
+      let(:input) { junit_xml_string }
+
+      it "returns TestResult objects" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results).to all(be_a(Wild::Analyzers::TestFlakes::Models::TestResult))
+      end
+
+      it "parses all test cases" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.size).to eq(3)
+      end
+
+      it "parses passing tests" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.select(&:passed?).size).to be >= 1
+      end
+
+      it "parses failing tests with error message" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        failed = results.find(&:failed?)
+        expect(failed).not_to be_nil
+        expect(failed.error_message).not_to be_nil
+      end
+
+      it "parses duration_ms" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.first.duration_ms).to be_a(Numeric)
+      end
+    end
+
+    context "with testsuites root element" do
+      let(:input) do
+        <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <testsuites>
+            <testsuite name="Suite1">
+              <testcase classname="Foo" name="test_it" time="0.1"/>
+            </testsuite>
+          </testsuites>
+        XML
+      end
+
+      it "parses successfully" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.size).to eq(1)
+      end
+    end
+
+    context "with skipped tests" do
+      let(:input) do
+        <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <testsuite name="Suite">
+            <testcase classname="Foo" name="skipped_test"><skipped/></testcase>
+          </testsuite>
+        XML
+      end
+
+      it "maps to :skipped status" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.first.status).to eq(:skipped)
+      end
+    end
+
+    context "with empty input" do
+      it "raises ParseError" do
+        expect { parser.parse("") }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+
+    context "with invalid XML" do
+      it "raises ParseError" do
+        expect { parser.parse("<not valid xml") }
+          .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+
+    context "with wrong root element" do
+      it "raises ParseError" do
+        xml = '<?xml version="1.0"?><report><testcase name="x"/></report>'
+        expect { parser.parse(xml) }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/parsers/minitest_json_spec.rb
+++ b/spec/wild/analyzers/test_flakes/parsers/minitest_json_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Parsers::MinitestJson do
+  subject(:parser) { described_class.new }
+
+  describe "#parse" do
+    context 'with valid minitest JSON using "tests" key' do
+      let(:input) { minitest_json_string }
+
+      it "returns TestResult objects" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results).to all(be_a(Wild::Analyzers::TestFlakes::Models::TestResult))
+      end
+
+      it "parses all tests" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.size).to eq(3)
+      end
+
+      it "maps pass to :passed" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.select(&:passed?).size).to be >= 1
+      end
+
+      it "maps fail to :failed with error" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        failed = results.find(&:failed?)
+        expect(failed).not_to be_nil
+      end
+    end
+
+    context 'with "results" key instead of "tests"' do
+      let(:input) do
+        JSON.generate({
+                        "results" => [
+                          { "name" => "test_foo", "class" => "FooTest", "result" => "pass", "time" => 0.05 }
+                        ]
+                      })
+      end
+
+      it "parses successfully" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.size).to eq(1)
+      end
+    end
+
+    context "with skip status" do
+      let(:input) do
+        JSON.generate({
+                        "tests" => [
+                          { "name" => "test_skip", "class" => "FooTest", "result" => "skip" }
+                        ]
+                      })
+      end
+
+      it "maps to :skipped" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.first.status).to eq(:skipped)
+      end
+    end
+
+    context "with error status" do
+      let(:input) do
+        JSON.generate({
+                        "tests" => [
+                          { "name" => "test_err", "class" => "FooTest", "result" => "error", "error" => "boom" }
+                        ]
+                      })
+      end
+
+      it "maps to :errored" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.first.status).to eq(:errored)
+      end
+    end
+
+    context "with empty input" do
+      it "raises ParseError" do
+        expect { parser.parse("") }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+
+    context "with invalid JSON" do
+      it "raises ParseError" do
+        expect { parser.parse("not json") }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+
+    context "with missing tests key" do
+      it "raises ParseError" do
+        expect { parser.parse('{"summary": {}}') }
+          .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/parsers/rspec_json_spec.rb
+++ b/spec/wild/analyzers/test_flakes/parsers/rspec_json_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Parsers::RspecJson do
+  subject(:parser) { described_class.new }
+
+  describe "#parse" do
+    context "with valid RSpec JSON" do
+      let(:input) { rspec_json_string }
+
+      it "returns an array of TestResult objects" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results).to all(be_a(Wild::Analyzers::TestFlakes::Models::TestResult))
+      end
+
+      it "parses the correct number of examples" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.size).to eq(3)
+      end
+
+      it "maps passed status correctly" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        passed = results.select(&:passed?)
+        expect(passed.size).to be >= 1
+      end
+
+      it "maps failed status correctly" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        failed = results.select(&:failed?)
+        expect(failed.size).to be >= 1
+      end
+
+      it "captures error messages for failures" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        failed = results.find(&:failed?)
+        expect(failed.error_message).to include("expected true but got false")
+      end
+
+      it "captures duration_ms" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.first.duration_ms).to be_a(Numeric)
+      end
+    end
+
+    context "with pending status" do
+      let(:input) do
+        rspec_json_string(examples: [
+                            {
+                              "id" => "./spec/foo_spec.rb[1:1]",
+                              "description" => "does something",
+                              "full_description" => "Foo does something",
+                              "status" => "pending",
+                              "file_path" => "./spec/foo_spec.rb",
+                              "line_number" => 5
+                            }
+                          ])
+      end
+
+      it "maps pending status to :pending" do
+        results = parser.parse(input, run_id: "run-001", timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP)
+        expect(results.first.status).to eq(:pending)
+      end
+    end
+
+    context "when using class method" do
+      it "works as a class method" do
+        results = described_class.parse(
+          rspec_json_string,
+          run_id: "run-001",
+          timestamp: Wild::Analyzers::TestFlakes::TestSupport::Fixtures::BASE_TIMESTAMP
+        )
+        expect(results).to be_an(Array)
+      end
+    end
+
+    context "with empty input" do
+      it "raises ParseError" do
+        expect { parser.parse("") }.to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+
+    context "with invalid JSON" do
+      it "raises ParseError" do
+        expect { parser.parse("{ not valid json") }
+          .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+
+    context "with JSON missing examples key" do
+      it "raises ParseError" do
+        expect { parser.parse('{"summary": {}}') }
+          .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+
+    context "with examples that is not an array" do
+      it "raises ParseError" do
+        expect { parser.parse('{"examples": "bad"}') }
+          .to raise_error(Wild::Analyzers::TestFlakes::ParseError)
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/triage/engine_spec.rb
+++ b/spec/wild/analyzers/test_flakes/triage/engine_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Triage::Engine do
+  subject(:engine) { described_class.new }
+
+  let(:records) do
+    multiple_flake_records(count: 3).tap do |recs|
+      # Assign root causes
+      recs.map.with_index do |rec, i|
+        cause = Wild::Analyzers::TestFlakes::Models::RootCause.new(
+          category: :timing_dependent,
+          confidence: 0.5 + (i * 0.1)
+        )
+        Wild::Analyzers::TestFlakes::Models::FlakeRecord.new(
+          test_identity: rec.test_identity,
+          results: rec.results,
+          root_causes: [cause]
+        )
+      end
+    end
+  end
+
+  describe "#triage" do
+    it "returns TriageEntry objects" do
+      entries = engine.triage(records)
+      expect(entries).to all(be_a(Wild::Analyzers::TestFlakes::Models::TriageEntry))
+    end
+
+    it "returns entries sorted by severity_score descending" do
+      entries = engine.triage(records)
+      scores = entries.map(&:severity_score)
+      expect(scores).to eq(scores.sort.reverse)
+    end
+
+    it "returns one entry per flake record" do
+      entries = engine.triage(records)
+      expect(entries.size).to eq(records.size)
+    end
+
+    it "assigns severity to each entry" do
+      entries = engine.triage(records)
+      entries.each do |entry|
+        expect(Wild::Analyzers::TestFlakes::Models::TriageEntry::SEVERITIES).to include(entry.severity)
+      end
+    end
+
+    it "populates remediations" do
+      entries = engine.triage(records)
+      entries.each do |entry|
+        expect(entry.remediations).to be_an(Array)
+      end
+    end
+
+    context "with empty input" do
+      it "returns empty array" do
+        expect(engine.triage([])).to eq([])
+      end
+    end
+
+    context "with invalid input" do
+      it "raises ArgumentError" do
+        expect { engine.triage("bad") }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with history store" do
+      let(:store) { Wild::Analyzers::TestFlakes::History::Store.new }
+
+      it "uses trend from history store" do
+        engine_with_store = described_class.new(history_store: store)
+        entries = engine_with_store.triage(records)
+        expect(entries).to all(be_a(Wild::Analyzers::TestFlakes::Models::TriageEntry))
+      end
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/triage/remediation_spec.rb
+++ b/spec/wild/analyzers/test_flakes/triage/remediation_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Triage::Remediation do
+  subject(:remediation) { described_class.new }
+
+  let(:timing_cause) do
+    Wild::Analyzers::TestFlakes::Models::RootCause.new(
+      category: :timing_dependent, confidence: 0.8
+    )
+  end
+
+  let(:external_cause) do
+    Wild::Analyzers::TestFlakes::Models::RootCause.new(
+      category: :external_dependency, confidence: 0.7
+    )
+  end
+
+  describe "#suggestions_for" do
+    it "returns timing suggestions for timing root cause" do
+      suggestions = remediation.suggestions_for([timing_cause])
+      expect(suggestions).not_to be_empty
+      expect(suggestions.first).to be_a(String)
+    end
+
+    it "returns external dependency suggestions" do
+      suggestions = remediation.suggestions_for([external_cause])
+      expect(suggestions).not_to be_empty
+    end
+
+    it "returns unknown suggestions for empty causes" do
+      suggestions = remediation.suggestions_for([])
+      expect(suggestions).to eq(described_class::SUGGESTIONS[:unknown])
+    end
+
+    it "returns unknown suggestions for nil" do
+      suggestions = remediation.suggestions_for(nil)
+      expect(suggestions).to eq(described_class::SUGGESTIONS[:unknown])
+    end
+
+    it "uses primary cause (highest confidence)" do
+      low_timing = Wild::Analyzers::TestFlakes::Models::RootCause.new(
+        category: :timing_dependent, confidence: 0.2
+      )
+      high_external = Wild::Analyzers::TestFlakes::Models::RootCause.new(
+        category: :external_dependency, confidence: 0.9
+      )
+      suggestions = remediation.suggestions_for([low_timing, high_external])
+      expect(suggestions).to eq(described_class::SUGGESTIONS[:external_dependency])
+    end
+  end
+
+  describe "#all_suggestions_for" do
+    it "combines suggestions from multiple causes" do
+      suggestions = remediation.all_suggestions_for([timing_cause, external_cause])
+      expect(suggestions.size).to be >= 2
+    end
+
+    it "returns at most 6 suggestions" do
+      all_causes = Wild::Analyzers::TestFlakes::Models::RootCause::CATEGORIES.map do |cat|
+        Wild::Analyzers::TestFlakes::Models::RootCause.new(category: cat, confidence: 0.5)
+      end
+      suggestions = remediation.all_suggestions_for(all_causes)
+      expect(suggestions.size).to be <= 6
+    end
+
+    it "returns unique suggestions" do
+      suggestions = remediation.all_suggestions_for([timing_cause, external_cause])
+      expect(suggestions).to eq(suggestions.uniq)
+    end
+  end
+end

--- a/spec/wild/analyzers/test_flakes/triage/severity_scorer_spec.rb
+++ b/spec/wild/analyzers/test_flakes/triage/severity_scorer_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Analyzers::TestFlakes::Triage::SeverityScorer do
+  subject(:scorer) { described_class.new }
+
+  let(:high_flake_record) do
+    cause = Wild::Analyzers::TestFlakes::Models::RootCause.new(
+      category: :timing_dependent, confidence: 0.8
+    )
+    flake_record_with(root_causes: [cause], flake_rate_numerator: 4, total: 5)
+  end
+
+  let(:low_flake_record) do
+    flake_record_with(flake_rate_numerator: 1, total: 10)
+  end
+
+  describe "#score" do
+    it "returns a float between 0 and 1" do
+      score = scorer.score(high_flake_record)
+      expect(score).to be >= 0.0
+      expect(score).to be <= 1.0
+    end
+
+    it "scores high-flake records higher than low-flake records" do
+      high_score = scorer.score(high_flake_record)
+      low_score = scorer.score(low_flake_record)
+      expect(high_score).to be > low_score
+    end
+
+    it "increases score for worsening trend" do
+      stable = scorer.score(high_flake_record, trend: :stable)
+      worsening = scorer.score(high_flake_record, trend: :worsening)
+      expect(worsening).to be >= stable
+    end
+
+    it "decreases score for improving trend" do
+      stable = scorer.score(high_flake_record, trend: :stable)
+      improving = scorer.score(high_flake_record, trend: :improving)
+      expect(improving).to be <= stable
+    end
+  end
+
+  describe "#severity_from_score" do
+    it "returns :critical for score >= 0.75" do
+      expect(scorer.severity_from_score(0.8)).to eq(:critical)
+    end
+
+    it "returns :high for score in [0.5, 0.75)" do
+      expect(scorer.severity_from_score(0.6)).to eq(:high)
+    end
+
+    it "returns :medium for score in [0.25, 0.5)" do
+      expect(scorer.severity_from_score(0.35)).to eq(:medium)
+    end
+
+    it "returns :low for score < 0.25" do
+      expect(scorer.severity_from_score(0.1)).to eq(:low)
+    end
+  end
+
+  describe "with custom weights" do
+    let(:scorer) do
+      described_class.new(weights: { flake_rate: 3.0, failure_count: 1.0, trend: 1.0, confidence: 1.0 })
+    end
+
+    it "applies custom weights in scoring" do
+      score = scorer.score(high_flake_record)
+      expect(score).to be_a(Float)
+    end
+  end
+end

--- a/spec/wild/configuration_spec.rb
+++ b/spec/wild/configuration_spec.rb
@@ -173,6 +173,26 @@ RSpec.describe Wild::Configuration do
     it "TestFlakes defaults classifier_corpus_path to nil (engineer-supplied)" do
       expect(analyzers.test_flakes.classifier_corpus_path).to be_nil
     end
+
+    # Flake-detection knobs carried from the old wild-test-flake-forensics gem
+    # (Role 5 PR-7). Defaults preserved verbatim.
+    it "TestFlakes defaults minimum_runs to 3" do
+      expect(analyzers.test_flakes.minimum_runs).to eq(3)
+    end
+
+    it "TestFlakes defaults flake_rate_threshold to 0.1" do
+      expect(analyzers.test_flakes.flake_rate_threshold).to eq(0.1)
+    end
+
+    it "TestFlakes defaults max_history_entries to 10_000" do
+      expect(analyzers.test_flakes.max_history_entries).to eq(10_000)
+    end
+
+    it "TestFlakes defaults severity_weights to all-1.0 four-signal map" do
+      expect(analyzers.test_flakes.severity_weights).to eq(
+        flake_rate: 1.0, failure_count: 1.0, trend: 1.0, confidence: 1.0
+      )
+    end
   end
 
   describe Wild::Configuration::Skillops do


### PR DESCRIPTION
## Summary

Role 5 PR-7 — moves `wild-test-flake-forensics` into `Wild::Analyzers::TestFlakes`. **Completes the structure move** for the `wild-rvv.7` Analyzers epic (Permission landed in PR #25). Tier 2 per ADR-0003.

## What landed

| Layer | Change |
|---|---|
| `lib/wild/analyzers/test_flakes/` | 21 source files moved (models, parsers, detection, analysis, triage, history, export) |
| `lib/wild/analyzers/test_flakes.rb` | New loader |
| `spec/wild/analyzers/test_flakes/` | 24 specs moved; `TestFixtures::` constant refs rewritten |
| `Wild::Configuration::Analyzers::TestFlakes` | Extended 1 → 5 settings (defaults verbatim) |
| `Wild::Analyzers::TestFlakes::Error` | `ParseError`, `DetectionError`, `ExportError` subtree |
| `version.rb` + `configuration.rb` (F1) | Deleted; `json_exporter` version → `Wild::VERSION` |

## RuboCop note

Pre-existing complexity in the moved code (`RootCauseAnalyzer` class length, several `AbcSize`/`ParameterLists`/`Complexity` methods) trips wild's stricter Metrics config — the source gem's `.rubocop.yml` was more permissive. **Localized inline disables per offense site with rationale**, not a refactor (Beck: structure move is behavior-preserving). Spec + fixtures get file-level disables.

## What is intentionally NOT in this PR

- **F3 golden-corpus classifier test** — `wild-rvv.7.1`
- **`coverage_analyzer` dedup** (Permission + TestFlakes share it) — `wild-rvv.7.2`
- **F6 export wire-or-delete** (Beck flagged 2 of 3 exporters) — `wild-rvv.5.4`
- Config setter validation + freeze machinery dropped; freeze adversarial spec deleted per F3

## Local verification

| Gate | Result |
|---|---|
| `bundle exec rspec` | **1238 examples, 0 failures** (981 prior + 257 new) |
| `bundle exec rubocop` | 229 files, **0 offenses** |
| `ruby -Ilib` smoke-load | `Wild::Analyzers::TestFlakes::*` resolves; `minimum_runs` → 3 |

## Bead linkage

- **`wild-rvv.7`** (epic, in_progress) — **both halves now structurally moved** (Permission #25 + TestFlakes here). Epic stays open for behavior children: `7.1` (F3 golden corpus), `7.2` (coverage_analyzer dedup), and the Fowler `detect_cycle` fix.

## Test plan

- [ ] CI green on Ruby 3.2 / 3.3 / 3.4
- [ ] CodeQL clean (watch for incomplete-sanitization in the moved exporters — same class of finding as PR #25's markdown escape)
- [ ] Codecov Analyzers delta ≥ 80%
- [ ] No new Packwerk boundary violations

- Jeremy Longshore
intentsolutions.io