### PR TITLE
feat(telemetry): move wild-transcript-pipeline into Wild::Telemetry::Pipeline (Role 5 PR-9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,35 @@ section splits into a separate file.
 
 ### Wild::Telemetry::Pipeline
 
-- _(pending: P1 code move from `wild-transcript-pipeline`)_
+- Moved 16 source files from `wild-transcript-pipeline/lib/wild_transcript_pipeline/`
+  into `lib/wild/telemetry/pipeline/` under the 3-deep
+  `Wild::Telemetry::Pipeline::*` namespace (Role 5 PR-9; second of three
+  Telemetry sub-namespace moves). Sub-directories preserved: `ingestion/`,
+  `normalization/`, `privacy/`, `models/`, `export/`. Module Zeitwerk-rewritten
+  from compact form. New loader at `lib/wild/telemetry/pipeline.rb` carries the
+  `Wild::Telemetry::Pipeline.process` convenience method (full ingest →
+  normalize → redact pipeline) from the old gem entry point.
+- 19 specs (unit + adversarial + integration) moved to
+  `spec/wild/telemetry/pipeline/`. `TranscriptFixtures` rewrapped as
+  `Wild::Telemetry::Pipeline::TestSupport::TranscriptFixtures`, wired into
+  spec_helper. Spec `WildTranscriptPipeline.process` calls + flat config
+  setters rewritten to the nested API.
+- **F1 — `Wild::Configuration::Telemetry::Pipeline` extended** from 1 setting
+  (`sequence_strategy` from PR-B) to 8: the 7 old-gem knobs
+  (`intent_confidence_threshold` 0.5, `max_turn_content_length` 10_000,
+  `max_turns_per_transcript` 1_000, `redaction_marker` "[REDACTED]",
+  `strip_absolute_paths` true, `strip_file_contents` true, `custom_patterns`
+  []) plus `sequence_strategy`. Defaults verbatim. Deleted `version.rb` +
+  `configuration.rb`; `json_exporter` metadata `version:` → `Wild::VERSION`;
+  orphaned `configuration_spec.rb` removed.
+- **MIN-Armstrong — `Wild::Telemetry::Pipeline::Error` subtree added**:
+  `IngestionError`, `NormalizationError`, `PrivacyError`, `ExportError`. Old
+  gem's `ConfigurationError` subsumed by `Wild::ConfigurationError`.
+- Pre-existing complexity (`Transcript` value-object ParameterLists,
+  `tool_extractor` AbcSize) handled with localized inline disables — no
+  refactor (behavior-preserving move).
+- **NOT in this PR** (deferred, `wild-rvv.5` children): F7 (`5.1`), F8 (`5.2`),
+  MIN-Kleppmann (`5.3`), F6 export audit (`5.4`).
 
 ### Wild::Telemetry::Analysis
 

--- a/lib/wild.rb
+++ b/lib/wild.rb
@@ -10,6 +10,7 @@ require "wild/skillops"
 require "wild/analyzers/permission"
 require "wild/analyzers/test_flakes"
 require "wild/telemetry/collector"
+require "wild/telemetry/pipeline"
 
 # wild — Rails engine + generator: ten Wild::* namespaces consolidated into one
 # mountable gem. Council-blessed Topology A. See 000-docs/adr/ADR-0001-topology.md

--- a/lib/wild/configuration.rb
+++ b/lib/wild/configuration.rb
@@ -122,9 +122,32 @@ module Wild
         end
       end
 
-      Pipeline = Struct.new(:sequence_strategy, keyword_init: true) do
+      # Pipeline carries the transcript-pipeline knobs the old gem exposed
+      # plus the PR-B `sequence_strategy` flag. Defaults preserved verbatim;
+      # the gem's per-setter validation + freeze! machinery is NOT carried
+      # over (no-freeze design).
+      Pipeline = Struct.new(
+        :sequence_strategy,
+        :intent_confidence_threshold,
+        :max_turn_content_length,
+        :max_turns_per_transcript,
+        :redaction_marker,
+        :strip_absolute_paths,
+        :strip_file_contents,
+        :custom_patterns,
+        keyword_init: true
+      ) do
         def initialize(**kwargs)
-          super(sequence_strategy: kwargs.fetch(:sequence_strategy, :ingest_order))
+          super(
+            sequence_strategy: kwargs.fetch(:sequence_strategy, :ingest_order),
+            intent_confidence_threshold: kwargs.fetch(:intent_confidence_threshold, 0.5),
+            max_turn_content_length: kwargs.fetch(:max_turn_content_length, 10_000),
+            max_turns_per_transcript: kwargs.fetch(:max_turns_per_transcript, 1_000),
+            redaction_marker: kwargs.fetch(:redaction_marker, "[REDACTED]"),
+            strip_absolute_paths: kwargs.fetch(:strip_absolute_paths, true),
+            strip_file_contents: kwargs.fetch(:strip_file_contents, true),
+            custom_patterns: kwargs.fetch(:custom_patterns, [])
+          )
         end
       end
 

--- a/lib/wild/error.rb
+++ b/lib/wild/error.rb
@@ -92,6 +92,23 @@ module Wild
       # Raised when the backing store cannot persist or read events.
       class StorageError < Error; end
     end
+
+    # Pipeline sub-namespace errors (from wild-transcript-pipeline).
+    module Pipeline
+      class Error < Wild::Telemetry::Error; end
+
+      # Raised when an ingestion adapter cannot parse its input.
+      class IngestionError < Error; end
+
+      # Raised when turn/intent/tool normalization fails.
+      class NormalizationError < Error; end
+
+      # Raised when privacy redaction fails.
+      class PrivacyError < Error; end
+
+      # Raised when transcript export fails.
+      class ExportError < Error; end
+    end
   end
 
   module Hooks

--- a/lib/wild/telemetry/pipeline.rb
+++ b/lib/wild/telemetry/pipeline.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Wild::Telemetry::Pipeline — Tier 1 per ADR-0003. Transcript ingestion +
+# normalization: parses raw agent transcripts (Claude Code / MCP logs / generic)
+# via adapters, normalizes turns, detects intents, extracts tool references,
+# and redacts for privacy.
+#
+# Reads its policy from Wild.config.telemetry.pipeline. Code moved from the
+# old wild-transcript-pipeline gem in Role 5 PR-9 (second of three Telemetry
+# sub-namespace moves).
+#
+# Deferred behavior changes tracked under wild-rvv.5's children (F7/F8/
+# MIN-Kleppmann/F6).
+
+# Models
+require "wild/telemetry/pipeline/models/turn"
+require "wild/telemetry/pipeline/models/intent"
+require "wild/telemetry/pipeline/models/tool_reference"
+require "wild/telemetry/pipeline/models/transcript"
+require "wild/telemetry/pipeline/models/transcript_batch"
+
+# Ingestion adapters
+require "wild/telemetry/pipeline/ingestion/base_adapter"
+require "wild/telemetry/pipeline/ingestion/claude_code_adapter"
+require "wild/telemetry/pipeline/ingestion/mcp_log_adapter"
+require "wild/telemetry/pipeline/ingestion/generic_adapter"
+
+# Normalization
+require "wild/telemetry/pipeline/normalization/turn_normalizer"
+require "wild/telemetry/pipeline/normalization/intent_detector"
+require "wild/telemetry/pipeline/normalization/tool_extractor"
+
+# Privacy
+require "wild/telemetry/pipeline/privacy/content_filter"
+require "wild/telemetry/pipeline/privacy/redactor"
+
+# Export — flagged for F6 wire-or-delete audit under wild-rvv.5.4.
+require "wild/telemetry/pipeline/export/json_exporter"
+require "wild/telemetry/pipeline/export/markdown_exporter"
+
+module Wild
+  module Telemetry
+    module Pipeline
+      class << self
+        # Convenience: run the full pipeline on raw input. Returns an array of
+        # normalized, redacted Transcript objects.
+        def process(input, adapter:, source_id: nil, config: Wild.config.telemetry.pipeline)
+          transcripts = adapter.parse(input, source_id: source_id)
+          pipe = build_pipeline
+          transcripts.map { |t| run_pipeline(t, pipe, config) }
+        end
+
+        private
+
+        def build_pipeline
+          {
+            normalizer: Normalization::TurnNormalizer.new,
+            intent_detector: Normalization::IntentDetector.new,
+            tool_extractor: Normalization::ToolExtractor.new,
+            redactor: Privacy::Redactor.new
+          }
+        end
+
+        def run_pipeline(transcript, pipe, config)
+          turns = pipe[:normalizer].normalize(transcript.turns, config: config)
+          turns = turns.map { |t| pipe[:redactor].redact_turn(t, config: config) }
+          intents = pipe[:intent_detector].detect(turns, config: config)
+          tool_refs = pipe[:tool_extractor].extract(turns)
+          enriched = build_enriched_transcript(transcript, turns, intents, tool_refs)
+          pipe[:redactor].redact_transcript(enriched, config: config)
+        end
+
+        def build_enriched_transcript(transcript, turns, intents, tool_refs)
+          Models::Transcript.new(
+            source_type: transcript.source_type,
+            source_id: transcript.source_id,
+            turns: turns,
+            intents: intents,
+            tool_references: tool_refs,
+            metadata: transcript.metadata.merge(processed: true),
+            created_at: transcript.created_at
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/export/json_exporter.rb
+++ b/lib/wild/telemetry/pipeline/export/json_exporter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Export
+        class JsonExporter
+          def export(transcripts, metadata: {})
+            raise ExportError, "transcripts must be an Array" unless transcripts.is_a?(Array)
+
+            payload = build_payload(transcripts, metadata)
+            JSON.generate(payload)
+          rescue JSON::GeneratorError => e
+            raise ExportError, "JSON generation failed: #{e.message}"
+          end
+
+          def export_batch(batch, metadata: {})
+            raise ExportError, "batch must be a TranscriptBatch" unless batch.is_a?(Models::TranscriptBatch)
+
+            export(batch.transcripts, metadata: batch.metadata.merge(metadata))
+          end
+
+          private
+
+          def build_payload(transcripts, metadata)
+            {
+              metadata: base_metadata.merge(metadata),
+              summary: build_summary(transcripts),
+              transcripts: transcripts.map(&:to_h)
+            }
+          end
+
+          def base_metadata
+            {
+              generated_at: Time.now.utc.iso8601,
+              version: Wild::VERSION,
+              schema_version: "1.0"
+            }
+          end
+
+          def build_summary(transcripts)
+            {
+              transcript_count: transcripts.size,
+              total_turns: transcripts.sum(&:turn_count),
+              total_intents: transcripts.sum(&:intent_count),
+              total_tool_references: transcripts.sum(&:tool_reference_count),
+              source_types: transcripts.map(&:source_type).uniq
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/export/markdown_exporter.rb
+++ b/lib/wild/telemetry/pipeline/export/markdown_exporter.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Export
+        class MarkdownExporter
+          ROLE_LABELS = {
+            user: "User",
+            assistant: "Assistant",
+            system: "System",
+            tool: "Tool"
+          }.freeze
+
+          def export(transcripts, metadata: {})
+            raise ExportError, "transcripts must be an Array" unless transcripts.is_a?(Array)
+
+            lines = build_header(transcripts, metadata)
+            append_body(lines, transcripts)
+            lines.flatten.join("\n")
+          end
+
+          private
+
+          def build_header(transcripts, metadata)
+            ["# Transcript Export", "", build_header_metadata(transcripts, metadata), "", "---", ""]
+          end
+
+          def append_body(lines, transcripts)
+            if transcripts.empty?
+              lines << "_No transcripts found._"
+            else
+              transcripts.each_with_index do |transcript, idx|
+                lines << build_transcript_section(transcript, idx + 1)
+                lines << ""
+              end
+            end
+          end
+
+          def build_header_metadata(transcripts, metadata)
+            [
+              "**Generated:** #{Time.now.utc.iso8601}",
+              "**Transcripts:** #{transcripts.size}",
+              "**Total Turns:** #{transcripts.sum(&:turn_count)}",
+              metadata.any? ? "**Metadata:** #{metadata.map { |k, v| "#{k}=#{v}" }.join(", ")}" : nil
+            ].compact
+          end
+
+          def build_transcript_section(transcript, number)
+            lines = build_transcript_header(transcript, number)
+            append_intents(lines, transcript)
+            append_tool_references(lines, transcript)
+            append_turns(lines, transcript)
+            lines
+          end
+
+          def build_transcript_header(transcript, number)
+            [
+              "## Transcript #{number}: `#{transcript.source_id}`",
+              "",
+              "- **Source Type:** #{transcript.source_type}",
+              "- **Created:** #{transcript.created_at.iso8601}",
+              "- **Turns:** #{transcript.turn_count}",
+              "- **Intents:** #{transcript.intent_count}",
+              "- **Tool References:** #{transcript.tool_reference_count}",
+              ""
+            ]
+          end
+
+          def append_intents(lines, transcript)
+            return unless transcript.intents.any?
+
+            lines << "### Detected Intents"
+            lines << ""
+            transcript.intents.each do |intent|
+              lines << "- (#{format("%.2f", intent.confidence)}) #{intent.description}"
+            end
+            lines << ""
+          end
+
+          def append_tool_references(lines, transcript)
+            return unless transcript.tool_references.any?
+
+            lines << "### Tool References"
+            lines << ""
+            transcript.tool_references.each do |ref|
+              outcome_str = ref.outcome ? " -> #{ref.outcome}" : ""
+              lines << "- `#{ref.name}` (#{ref.action}#{outcome_str}) at turn #{ref.turn_index}"
+            end
+            lines << ""
+          end
+
+          def append_turns(lines, transcript)
+            lines << "### Turns"
+            lines << ""
+            transcript.turns.each_with_index { |turn, idx| lines << build_turn_block(turn, idx) }
+          end
+
+          def build_turn_block(turn, index)
+            label = ROLE_LABELS[turn.role] || turn.role.to_s.capitalize
+            ts = turn.timestamp ? " _(#{turn.timestamp.iso8601})_" : ""
+            [
+              "**[#{index}] #{label}**#{ts}",
+              "",
+              turn.content.empty? ? "_empty_" : turn.content,
+              ""
+            ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/ingestion/base_adapter.rb
+++ b/lib/wild/telemetry/pipeline/ingestion/base_adapter.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Ingestion
+        class BaseAdapter
+          def self.parse(input, source_id: nil)
+            new.parse(input, source_id: source_id)
+          end
+
+          def parse(_input, source_id: nil)
+            raise NotImplementedError, "#{self.class}#parse is not implemented"
+          end
+
+          private
+
+          def require_non_empty!(input)
+            raise IngestionError, "input cannot be nil or empty" if input.to_s.strip.empty?
+          end
+
+          def generate_source_id
+            "source-#{Time.now.utc.to_i}"
+          end
+
+          def coerce_source_id(source_id)
+            (source_id.to_s.strip.empty? ? generate_source_id : source_id).freeze
+          end
+
+          def parse_timestamp(value)
+            return nil if value.nil? || value.to_s.strip.empty?
+
+            require "time"
+            Time.parse(value.to_s).utc
+          rescue ArgumentError
+            nil
+          end
+
+          def build_turn(role:, content:, timestamp: nil, metadata: {})
+            Models::Turn.new(
+              role: role,
+              content: content.to_s,
+              timestamp: timestamp,
+              metadata: metadata
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/ingestion/claude_code_adapter.rb
+++ b/lib/wild/telemetry/pipeline/ingestion/claude_code_adapter.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Ingestion
+        class ClaudeCodeAdapter < BaseAdapter
+          TYPE_TO_ROLE = {
+            "human" => :user,
+            "user" => :user,
+            "assistant" => :assistant,
+            "tool_use" => :tool,
+            "tool_result" => :tool,
+            "system" => :system
+          }.freeze
+
+          def parse(input, source_id: nil)
+            require_non_empty!(input)
+
+            lines = input.to_s.strip.split("\n").reject { |l| l.strip.empty? }
+            raise IngestionError, "input contains no non-empty lines" if lines.empty?
+
+            sid = coerce_source_id(source_id)
+            turns = parse_lines(lines)
+
+            [Models::Transcript.new(
+              source_type: :claude_code,
+              source_id: sid,
+              turns: turns,
+              metadata: { adapter: "ClaudeCodeAdapter", line_count: lines.size }
+            )]
+          end
+
+          private
+
+          def parse_lines(lines)
+            lines.filter_map { |line| parse_line(line) }
+          end
+
+          def parse_line(line)
+            parsed = JSON.parse(line)
+            return nil unless parsed.is_a?(Hash)
+
+            role = resolve_role(parsed)
+            return nil if role.nil?
+
+            content = extract_content(parsed)
+            timestamp = parse_timestamp(parsed["timestamp"])
+            metadata = extract_metadata(parsed)
+
+            build_turn(role: role, content: content, timestamp: timestamp, metadata: metadata)
+          rescue JSON::ParserError
+            nil
+          end
+
+          def resolve_role(parsed)
+            type = parsed["type"].to_s
+            TYPE_TO_ROLE[type]
+          end
+
+          def extract_content(parsed)
+            return extract_tool_use_content(parsed) if parsed["type"] == "tool_use"
+            return extract_tool_result_content(parsed) if parsed["type"] == "tool_result"
+
+            parsed["message"] || parsed["content"] || ""
+          end
+
+          def extract_tool_use_content(parsed)
+            name = parsed["name"] || "unknown_tool"
+            input = parsed["input"]
+            input ? "#{name}(#{JSON.generate(input)})" : name
+          end
+
+          def extract_tool_result_content(parsed)
+            name = parsed["name"] || "unknown_tool"
+            output = parsed["output"] || parsed["content"] || ""
+            "[tool_result:#{name}] #{output}"
+          end
+
+          def extract_metadata(parsed)
+            meta = {}
+            meta[:tool_name] = parsed["name"] if parsed["name"]
+            meta[:tool_input] = parsed["input"] if parsed["input"]
+            meta[:tool_output] = parsed["output"] if parsed["output"]
+            meta
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/ingestion/generic_adapter.rb
+++ b/lib/wild/telemetry/pipeline/ingestion/generic_adapter.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Ingestion
+        class GenericAdapter < BaseAdapter
+          ROLE_MAP = {
+            "user" => :user,
+            "human" => :user,
+            "assistant" => :assistant,
+            "ai" => :assistant,
+            "bot" => :assistant,
+            "system" => :system,
+            "tool" => :tool,
+            "function" => :tool
+          }.freeze
+
+          def parse(input, source_id: nil)
+            require_non_empty!(input)
+
+            data = parse_json(input)
+            sid = coerce_source_id(source_id)
+            raw_turns = extract_turns(data)
+            turns = build_turns(raw_turns)
+
+            [Models::Transcript.new(
+              source_type: :generic,
+              source_id: sid,
+              turns: turns,
+              metadata: { adapter: "GenericAdapter" }
+            )]
+          end
+
+          private
+
+          def parse_json(input)
+            JSON.parse(input.to_s.strip)
+          rescue JSON::ParserError => e
+            raise IngestionError, "Failed to parse generic conversation JSON: #{e.message}"
+          end
+
+          def extract_turns(data)
+            if data.is_a?(Hash) && data["turns"].is_a?(Array)
+              data["turns"]
+            elsif data.is_a?(Hash) && data["messages"].is_a?(Array)
+              data["messages"]
+            elsif data.is_a?(Array)
+              data
+            else
+              raise IngestionError, 'Generic JSON must contain a "turns", "messages" array, or be an array itself'
+            end
+          end
+
+          def build_turns(raw_turns)
+            raw_turns.filter_map { |entry| build_turn_from_entry(entry) }
+          end
+
+          def build_turn_from_entry(entry)
+            return nil unless entry.is_a?(Hash)
+
+            role_str = entry["role"].to_s.downcase
+            role = ROLE_MAP[role_str]
+            return nil if role.nil?
+
+            content = entry["content"].to_s
+            timestamp = parse_timestamp(entry["timestamp"])
+            metadata = entry.except("role", "content", "timestamp")
+
+            build_turn(role: role, content: content, timestamp: timestamp, metadata: metadata)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/ingestion/mcp_log_adapter.rb
+++ b/lib/wild/telemetry/pipeline/ingestion/mcp_log_adapter.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Ingestion
+        class McpLogAdapter < BaseAdapter
+          def parse(input, source_id: nil)
+            require_non_empty!(input)
+
+            parsed = parse_json_array(input)
+            sid = coerce_source_id(source_id)
+            turns = build_turns_from_pairs(parsed)
+
+            [Models::Transcript.new(
+              source_type: :mcp_log,
+              source_id: sid,
+              turns: turns,
+              metadata: { adapter: "McpLogAdapter", message_count: parsed.size }
+            )]
+          end
+
+          private
+
+          def parse_json_array(input)
+            data = JSON.parse(input.to_s.strip)
+            raise IngestionError, "MCP log must be a JSON array, got: #{data.class}" unless data.is_a?(Array)
+
+            data
+          rescue JSON::ParserError => e
+            raise IngestionError, "Failed to parse MCP log JSON: #{e.message}"
+          end
+
+          def build_turns_from_pairs(messages)
+            requests = {}
+            turns = []
+
+            messages.each do |msg|
+              next unless msg.is_a?(Hash)
+
+              if request?(msg)
+                requests[msg["id"]] = msg
+                turns << build_request_turn(msg)
+              elsif response?(msg)
+                turns << build_response_turn(msg, requests[msg["id"]])
+              end
+            end
+
+            turns.compact
+          end
+
+          def request?(msg)
+            msg.key?("method") && msg.key?("id")
+          end
+
+          def response?(msg)
+            (msg.key?("result") || msg.key?("error")) && msg.key?("id") && !msg.key?("method")
+          end
+
+          def build_request_turn(msg)
+            method = msg["method"] || "unknown"
+            params = msg["params"] || {}
+            tool_name = params["name"] || method
+            content = build_request_content(method, params)
+
+            build_turn(
+              role: :user,
+              content: content,
+              metadata: { mcp_id: msg["id"], method: method, tool_name: tool_name }
+            )
+          end
+
+          def build_request_content(method, params)
+            if method == "tools/call"
+              name = params["name"] || "unknown"
+              args = params["arguments"] || {}
+              "[mcp:request] tools/call #{name}(#{JSON.generate(args)})"
+            else
+              "[mcp:request] #{method} #{JSON.generate(params)}"
+            end
+          end
+
+          def build_response_turn(msg, _request)
+            if msg.key?("error")
+              build_turn(
+                role: :tool,
+                content: "[mcp:error] #{JSON.generate(msg["error"])}",
+                metadata: { mcp_id: msg["id"], mcp_error: true }
+              )
+            else
+              content = extract_result_content(msg["result"])
+              build_turn(
+                role: :tool,
+                content: "[mcp:result] #{content}",
+                metadata: { mcp_id: msg["id"] }
+              )
+            end
+          end
+
+          def extract_result_content(result)
+            return "" if result.nil?
+
+            if result.is_a?(Hash) && result["content"].is_a?(Array)
+              result["content"].filter_map { |c| c["text"] if c.is_a?(Hash) }.join(" ")
+            else
+              JSON.generate(result)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/models/intent.rb
+++ b/lib/wild/telemetry/pipeline/models/intent.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Models
+        class Intent
+          attr_reader :description, :confidence, :source_turn_index
+
+          def initialize(description:, confidence:, source_turn_index:)
+            raise ArgumentError, "description must be a non-empty String" unless valid_string?(description)
+
+            validate_confidence!(confidence)
+            validate_turn_index!(source_turn_index)
+
+            @description = description.freeze
+            @confidence = confidence.to_f
+            @source_turn_index = source_turn_index
+          end
+
+          def to_h
+            {
+              description: description,
+              confidence: confidence,
+              source_turn_index: source_turn_index
+            }
+          end
+
+          private
+
+          def valid_string?(value)
+            value.is_a?(String) && !value.strip.empty?
+          end
+
+          def validate_confidence!(value)
+            return if value.is_a?(Numeric) && value >= 0.0 && value <= 1.0
+
+            raise ArgumentError, "confidence must be between 0.0 and 1.0, got: #{value.inspect}"
+          end
+
+          def validate_turn_index!(value)
+            return if value.is_a?(Integer) && value >= 0
+
+            raise ArgumentError, "source_turn_index must be a non-negative Integer, got: #{value.inspect}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/models/tool_reference.rb
+++ b/lib/wild/telemetry/pipeline/models/tool_reference.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Models
+        class ToolReference
+          VALID_ACTIONS = %i[called mentioned failed not_found].freeze
+          VALID_OUTCOMES = %i[success error not_available].freeze
+
+          attr_reader :name, :action, :outcome, :turn_index
+
+          def initialize(name:, action:, turn_index:, outcome: nil)
+            raise ArgumentError, "name must be a non-empty String" unless valid_string?(name)
+
+            validate_action!(action)
+            validate_outcome!(outcome) unless outcome.nil?
+            raise ArgumentError, "turn_index must be a non-negative Integer" unless valid_index?(turn_index)
+
+            @name = name.freeze
+            @action = action.to_sym
+            @outcome = outcome&.to_sym
+            @turn_index = turn_index
+          end
+
+          def to_h
+            {
+              name: name,
+              action: action,
+              outcome: outcome,
+              turn_index: turn_index
+            }
+          end
+
+          private
+
+          def valid_string?(value)
+            value.is_a?(String) && !value.strip.empty?
+          end
+
+          def valid_index?(value)
+            value.is_a?(Integer) && value >= 0
+          end
+
+          def validate_action!(action)
+            sym = action.to_sym
+            return if VALID_ACTIONS.include?(sym)
+
+            raise ArgumentError, "action must be one of #{VALID_ACTIONS.inspect}, got: #{action.inspect}"
+          end
+
+          def validate_outcome!(outcome)
+            sym = outcome.to_sym
+            return if VALID_OUTCOMES.include?(sym)
+
+            raise ArgumentError, "outcome must be one of #{VALID_OUTCOMES.inspect}, got: #{outcome.inspect}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/models/transcript.rb
+++ b/lib/wild/telemetry/pipeline/models/transcript.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Models
+        class Transcript
+          attr_reader :source_type, :source_id, :turns, :intents, :tool_references, :metadata, :created_at
+
+          # rubocop:disable Metrics/ParameterLists
+          def initialize(source_type:, source_id:, turns: [], intents: [], tool_references: [], metadata: {},
+                         created_at: nil)
+            validate!(source_type, source_id, turns, intents, tool_references, metadata)
+            assign!(source_type, source_id, turns, intents, tool_references, metadata, created_at)
+          end
+          # rubocop:enable Metrics/ParameterLists
+
+          def turn_count
+            turns.size
+          end
+
+          def intent_count
+            intents.size
+          end
+
+          def tool_reference_count
+            tool_references.size
+          end
+
+          def to_h
+            {
+              source_type: source_type,
+              source_id: source_id,
+              created_at: created_at.iso8601,
+              turn_count: turn_count,
+              intent_count: intent_count,
+              tool_reference_count: tool_reference_count,
+              turns: turns.map(&:to_h),
+              intents: intents.map(&:to_h),
+              tool_references: tool_references.map(&:to_h),
+              metadata: metadata
+            }
+          end
+
+          private
+
+          # rubocop:disable Metrics/ParameterLists -- 6-field domain value object
+          def validate!(source_type, source_id, turns, intents, tool_references, metadata)
+            raise ArgumentError, "source_type must be a Symbol" unless source_type.is_a?(Symbol)
+            raise ArgumentError, "source_id must be a non-empty String" unless valid_string?(source_id)
+            raise ArgumentError, "turns must be an Array" unless turns.is_a?(Array)
+            raise ArgumentError, "intents must be an Array" unless intents.is_a?(Array)
+            raise ArgumentError, "tool_references must be an Array" unless tool_references.is_a?(Array)
+            raise ArgumentError, "metadata must be a Hash" unless metadata.is_a?(Hash)
+          end
+          # rubocop:enable Metrics/ParameterLists
+
+          # rubocop:disable Metrics/ParameterLists -- 7-field domain value object
+          def assign!(source_type, source_id, turns, intents, tool_references, metadata, created_at)
+            @source_type = source_type
+            @source_id = source_id.freeze
+            @turns = turns.freeze
+            @intents = intents.freeze
+            @tool_references = tool_references.freeze
+            @metadata = metadata.freeze
+            @created_at = created_at || Time.now.utc
+          end
+          # rubocop:enable Metrics/ParameterLists
+
+          def valid_string?(value)
+            value.is_a?(String) && !value.strip.empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/models/transcript_batch.rb
+++ b/lib/wild/telemetry/pipeline/models/transcript_batch.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Models
+        class TranscriptBatch
+          attr_reader :transcripts, :metadata, :created_at
+
+          def initialize(transcripts: [], metadata: {}, created_at: nil)
+            raise ArgumentError, "transcripts must be an Array" unless transcripts.is_a?(Array)
+            raise ArgumentError, "metadata must be a Hash" unless metadata.is_a?(Hash)
+
+            @transcripts = transcripts.freeze
+            @metadata = metadata.freeze
+            @created_at = created_at || Time.now.utc
+          end
+
+          delegate :size, to: :transcripts
+
+          delegate :empty?, to: :transcripts
+
+          def total_turns
+            transcripts.sum(&:turn_count)
+          end
+
+          def total_intents
+            transcripts.sum(&:intent_count)
+          end
+
+          def total_tool_references
+            transcripts.sum(&:tool_reference_count)
+          end
+
+          def source_types
+            transcripts.map(&:source_type).uniq
+          end
+
+          def to_h
+            {
+              created_at: created_at.iso8601,
+              transcript_count: size,
+              total_turns: total_turns,
+              total_intents: total_intents,
+              total_tool_references: total_tool_references,
+              source_types: source_types,
+              metadata: metadata,
+              transcripts: transcripts.map(&:to_h)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/models/turn.rb
+++ b/lib/wild/telemetry/pipeline/models/turn.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Models
+        class Turn
+          VALID_ROLES = %i[user assistant system tool].freeze
+
+          attr_reader :role, :content, :timestamp, :metadata
+
+          def initialize(role:, content:, timestamp: nil, metadata: {})
+            validate_role!(role)
+            raise ArgumentError, "content must be a String" unless content.is_a?(String)
+            raise ArgumentError, "metadata must be a Hash" unless metadata.is_a?(Hash)
+
+            @role = role.to_sym
+            @content = content.freeze
+            @timestamp = timestamp
+            @metadata = metadata.freeze
+          end
+
+          def to_h
+            {
+              role: role,
+              content: content,
+              timestamp: timestamp&.iso8601,
+              metadata: metadata
+            }
+          end
+
+          def tool_turn?
+            role == :tool
+          end
+
+          def user_turn?
+            role == :user
+          end
+
+          def assistant_turn?
+            role == :assistant
+          end
+
+          def system_turn?
+            role == :system
+          end
+
+          private
+
+          def validate_role!(role)
+            sym = role.to_sym
+            return if VALID_ROLES.include?(sym)
+
+            raise ArgumentError, "role must be one of #{VALID_ROLES.inspect}, got: #{role.inspect}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/normalization/intent_detector.rb
+++ b/lib/wild/telemetry/pipeline/normalization/intent_detector.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Normalization
+        class IntentDetector
+          INTENT_PATTERNS = [
+            { pattern: /\bI need to\b/i, description: "Expressed need", base_confidence: 0.65 },
+            { pattern: /\bI want to\b/i, description: "Expressed want", base_confidence: 0.60 },
+            { pattern: /\bLet me\b/i, description: "Initiating action", base_confidence: 0.55 },
+            { pattern: /\bLet me try\b/i, description: "Attempting action", base_confidence: 0.65 },
+            { pattern: /\bI('ll| will)\b/i, description: "Declared action", base_confidence: 0.60 },
+            { pattern: /\bI('m| am) going to\b/i, description: "Planned action", base_confidence: 0.70 },
+            { pattern: /\bI can't find a tool for\b/i, description: "Missing capability", base_confidence: 0.85 },
+            { pattern: /\bThere's no way to\b/i, description: "Identified limitation", base_confidence: 0.80 },
+            { pattern: /\bI don't have (a |the )?tool\b/i, description: "Missing tool", base_confidence: 0.85 },
+            { pattern: /\bI cannot\b/i, description: "Stated inability", base_confidence: 0.70 },
+            { pattern: /\bHere's (how|what)\b/i, description: "Providing explanation", base_confidence: 0.55 },
+            { pattern: /\bTo (do|accomplish|complete|fix)\b/i, description: "Goal statement", base_confidence: 0.60 }
+          ].freeze
+
+          TOOL_CALL_PATTERN = /\[?(tool_use|tool_call|function_call|mcp:request)\]?/i
+
+          def detect(turns, config: Wild.config.telemetry.pipeline)
+            raise NormalizationError, "turns must be an Array" unless turns.is_a?(Array)
+
+            threshold = config.intent_confidence_threshold
+            intents = []
+
+            turns.each_with_index do |turn, index|
+              next unless turn.assistant_turn? || turn.user_turn?
+
+              extract_intents(turn, index, threshold).each { |intent| intents << intent }
+            end
+
+            intents
+          end
+
+          private
+
+          def extract_intents(turn, index, threshold)
+            return [] if turn.content.strip.empty? || tool_content?(turn.content)
+
+            matched = matching_intents(turn.content, index, threshold)
+            best = matched.max_by(&:confidence)
+            best ? [best] : []
+          end
+
+          def matching_intents(content, index, threshold)
+            INTENT_PATTERNS.filter_map do |spec|
+              next unless content.match?(spec[:pattern])
+
+              confidence = compute_confidence(content, spec)
+              next if confidence < threshold
+
+              build_intent(content, spec, confidence, index)
+            end
+          end
+
+          def build_intent(content, spec, confidence, index)
+            Models::Intent.new(
+              description: build_description(content, spec),
+              confidence: confidence,
+              source_turn_index: index
+            )
+          end
+
+          def tool_content?(content)
+            content.match?(TOOL_CALL_PATTERN)
+          end
+
+          def build_description(content, spec)
+            snippet = content.split(/[.!?\n]/).first(2).join(" ").strip
+            snippet = snippet[0, 80] if snippet.length > 80
+            snippet.empty? ? spec[:description] : snippet
+          end
+
+          def compute_confidence(content, spec)
+            base = spec[:base_confidence]
+            length_factor = content.length > 200 ? 0.05 : 0.0
+            [base + length_factor, 1.0].min
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/normalization/tool_extractor.rb
+++ b/lib/wild/telemetry/pipeline/normalization/tool_extractor.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Normalization
+        class ToolExtractor
+          MCP_REF_PATTERN = %r{mcp://([a-z_][a-z0-9_-]*)}i
+          TOOL_USE_PATTERN = /\[tool_use\]\s*([a-z_][a-z0-9_-]*)/i
+          TOOL_RESULT_PATTERN = /\[tool_result:([a-z_][a-z0-9_-]*)\]/i
+          MCP_REQUEST_PATTERN = %r{\[mcp:request\]\s+tools/call\s+([a-z_][a-z0-9_-]*)}i
+          MCP_RESULT_PATTERN = /\[mcp:result\]/i
+          MCP_ERROR_PATTERN = /\[mcp:error\]/i
+          CANT_FIND_TOOL_PATTERN = /I can't find a tool for|I don't have (a |the )?tool|There's no way to/i
+          EXPLICIT_TOOL_CALL_PATTERN = /\b([a-z_][a-z0-9_]*)\s*\(\{/
+
+          def extract(turns)
+            raise NormalizationError, "turns must be an Array" unless turns.is_a?(Array)
+
+            refs = []
+            turns.each_with_index do |turn, index|
+              extract_from_turn(turn, index).each { |ref| refs << ref }
+            end
+            refs
+          end
+
+          private
+
+          # rubocop:disable Metrics/AbcSize
+          def extract_from_turn(turn, index)
+            content = turn.content
+            refs = []
+
+            refs.concat(extract_mcp_references(content, index, turn.metadata))
+            refs.concat(extract_tool_use_blocks(content, index))
+            refs.concat(extract_tool_results(content, index))
+            refs.concat(extract_cant_find_references(content, index))
+            refs.concat(extract_explicit_calls(content, index)) if refs.empty? && turn.assistant_turn?
+
+            refs.uniq { |r| [r.name, r.action, r.turn_index] }
+          end
+          # rubocop:enable Metrics/AbcSize
+
+          def extract_mcp_references(content, index, metadata)
+            refs = []
+            refs.concat(extract_mcp_request(content, index))
+            refs.concat(extract_mcp_result(content, index, metadata))
+            refs.concat(extract_mcp_error(content, index, metadata))
+            refs.concat(extract_mcp_uris(content, index))
+            refs
+          end
+
+          def extract_mcp_request(content, index)
+            return [] unless content.match?(MCP_REQUEST_PATTERN)
+
+            name = content.match(MCP_REQUEST_PATTERN)[1]
+            [build_ref(name: name, action: :called, turn_index: index)]
+          end
+
+          def extract_mcp_result(content, index, metadata)
+            return [] unless content.match?(MCP_RESULT_PATTERN)
+
+            tool_name = metadata[:tool_name] || "unknown_tool"
+            [build_ref(name: tool_name, action: :called, outcome: :success, turn_index: index)]
+          end
+
+          def extract_mcp_error(content, index, metadata)
+            return [] unless content.match?(MCP_ERROR_PATTERN)
+
+            tool_name = metadata[:tool_name] || "unknown_tool"
+            [build_ref(name: tool_name, action: :failed, outcome: :error, turn_index: index)]
+          end
+
+          def extract_mcp_uris(content, index)
+            content.scan(MCP_REF_PATTERN).flatten.uniq.map do |name|
+              build_ref(name: name, action: :mentioned, turn_index: index)
+            end
+          end
+
+          def extract_tool_use_blocks(content, index)
+            content.scan(TOOL_USE_PATTERN).flatten.uniq.map do |name|
+              build_ref(name: name, action: :called, turn_index: index)
+            end
+          end
+
+          def extract_tool_results(content, index)
+            content.scan(TOOL_RESULT_PATTERN).flatten.uniq.map do |name|
+              build_ref(name: name, action: :called, outcome: :success, turn_index: index)
+            end
+          end
+
+          def extract_cant_find_references(content, index)
+            return [] unless content.match?(CANT_FIND_TOOL_PATTERN)
+
+            [build_ref(name: "unknown_tool", action: :not_found, outcome: :not_available, turn_index: index)]
+          end
+
+          def extract_explicit_calls(content, index)
+            content.scan(EXPLICIT_TOOL_CALL_PATTERN).flatten.uniq.map do |name|
+              build_ref(name: name, action: :called, turn_index: index)
+            end
+          end
+
+          def build_ref(name:, action:, turn_index:, outcome: nil)
+            Models::ToolReference.new(
+              name: name,
+              action: action,
+              outcome: outcome,
+              turn_index: turn_index
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/normalization/turn_normalizer.rb
+++ b/lib/wild/telemetry/pipeline/normalization/turn_normalizer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Normalization
+        class TurnNormalizer
+          def normalize(turns, config: Wild.config.telemetry.pipeline)
+            raise NormalizationError, "turns must be an Array" unless turns.is_a?(Array)
+
+            limited = apply_turn_limit(turns, config.max_turns_per_transcript)
+            limited.map { |turn| normalize_turn(turn, config) }
+          end
+
+          private
+
+          def apply_turn_limit(turns, max)
+            return turns if turns.size <= max
+
+            turns.first(max)
+          end
+
+          def normalize_turn(turn, config)
+            normalized_content = truncate_content(turn.content, config.max_turn_content_length)
+
+            Models::Turn.new(
+              role: turn.role,
+              content: normalized_content,
+              timestamp: turn.timestamp,
+              metadata: turn.metadata
+            )
+          end
+
+          def truncate_content(content, max_length)
+            return content if content.length <= max_length
+
+            content[0, max_length]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/privacy/content_filter.rb
+++ b/lib/wild/telemetry/pipeline/privacy/content_filter.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Privacy
+        class ContentFilter
+          EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/
+          IP_PATTERN = /\b(?:\d{1,3}\.){3}\d{1,3}\b/
+          API_KEY_PATTERN = /\b(?:api[_-]?key|apikey|api_secret)\s*[:=]\s*['"]?[A-Za-z0-9_-]{16,}['"]?/i
+          AWS_ACCESS_KEY_PATTERN = /\b(?:AKIA|ASIA|AROA)[A-Z0-9]{16}\b/
+          AWS_SECRET_KEY_PATTERN = %r{\b(?:aws[_-]secret|secret_access_key)\s*[:=]\s*['"]?[A-Za-z0-9+/]{40}['"]?}i
+          GITHUB_TOKEN_PATTERN = /\bghp_[A-Za-z0-9]{36}\b|\bghs_[A-Za-z0-9]{36}\b/
+          BEARER_TOKEN_PATTERN = %r{\bBearer\s+[A-Za-z0-9._\-+/=]{20,}}i
+          ABSOLUTE_PATH_PATTERN = %r{\b(?:/(?:[^/\s]+/)*[^/\s]+)\b}
+          FILE_CONTENT_PATTERN = /```[a-z]*\n[\s\S]+?\n```/m
+
+          BUILT_IN_PATTERNS = [
+            EMAIL_PATTERN,
+            IP_PATTERN,
+            API_KEY_PATTERN,
+            AWS_ACCESS_KEY_PATTERN,
+            AWS_SECRET_KEY_PATTERN,
+            GITHUB_TOKEN_PATTERN,
+            BEARER_TOKEN_PATTERN
+          ].freeze
+
+          def sensitive?(content, config: Wild.config.telemetry.pipeline)
+            return false if content.to_s.strip.empty?
+
+            all_patterns(config).any? { |pattern| pattern.match?(content) } ||
+              (config.strip_absolute_paths && ABSOLUTE_PATH_PATTERN.match?(content)) ||
+              (config.strip_file_contents && FILE_CONTENT_PATTERN.match?(content))
+          end
+
+          def patterns_matching(content, config: Wild.config.telemetry.pipeline)
+            matched = []
+            all_patterns(config).each { |p| matched << p if p.match?(content) }
+            matched << ABSOLUTE_PATH_PATTERN if config.strip_absolute_paths && ABSOLUTE_PATH_PATTERN.match?(content)
+            matched << FILE_CONTENT_PATTERN if config.strip_file_contents && FILE_CONTENT_PATTERN.match?(content)
+            matched
+          end
+
+          private
+
+          def all_patterns(config)
+            BUILT_IN_PATTERNS + config.custom_patterns
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/pipeline/privacy/redactor.rb
+++ b/lib/wild/telemetry/pipeline/privacy/redactor.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module Privacy
+        class Redactor
+          def redact_transcript(transcript, config: Wild.config.telemetry.pipeline)
+            raise PrivacyError, "transcript must be a Transcript" unless transcript.is_a?(Models::Transcript)
+
+            redacted_turns = transcript.turns.map { |turn| redact_turn(turn, config: config) }
+
+            Models::Transcript.new(
+              source_type: transcript.source_type,
+              source_id: transcript.source_id,
+              turns: redacted_turns,
+              intents: transcript.intents,
+              tool_references: transcript.tool_references,
+              metadata: transcript.metadata.merge(redacted: true),
+              created_at: transcript.created_at
+            )
+          end
+
+          def redact_turn(turn, config: Wild.config.telemetry.pipeline)
+            raise PrivacyError, "turn must be a Turn" unless turn.is_a?(Models::Turn)
+
+            redacted_content = redact_content(turn.content, config: config)
+
+            Models::Turn.new(
+              role: turn.role,
+              content: redacted_content,
+              timestamp: turn.timestamp,
+              metadata: turn.metadata
+            )
+          end
+
+          def redact_content(content, config: Wild.config.telemetry.pipeline)
+            return content.to_s if content.to_s.strip.empty?
+
+            result = content.dup
+            result = apply_built_in_patterns(result, config)
+            apply_custom_patterns(result, config)
+          end
+
+          private
+
+          def apply_built_in_patterns(content, config)
+            marker = config.redaction_marker
+            result = content
+            result = redact_pattern(result, Privacy::ContentFilter::EMAIL_PATTERN, marker)
+            result = redact_pattern(result, Privacy::ContentFilter::API_KEY_PATTERN, marker)
+            result = redact_pattern(result, Privacy::ContentFilter::AWS_ACCESS_KEY_PATTERN, marker)
+            result = redact_pattern(result, Privacy::ContentFilter::AWS_SECRET_KEY_PATTERN, marker)
+            result = redact_pattern(result, Privacy::ContentFilter::GITHUB_TOKEN_PATTERN, marker)
+            result = redact_pattern(result, Privacy::ContentFilter::BEARER_TOKEN_PATTERN, marker)
+            result = redact_pattern(result, Privacy::ContentFilter::IP_PATTERN, marker)
+            result = redact_file_contents(result, marker) if config.strip_file_contents
+            result = redact_absolute_paths(result, marker) if config.strip_absolute_paths
+            result
+          end
+
+          def apply_custom_patterns(content, config)
+            config.custom_patterns.reduce(content) do |result, pattern|
+              redact_pattern(result, pattern, config.redaction_marker)
+            end
+          end
+
+          def redact_pattern(content, pattern, marker)
+            content.gsub(pattern, marker)
+          end
+
+          def redact_file_contents(content, marker)
+            content.gsub(Privacy::ContentFilter::FILE_CONTENT_PATTERN, "[#{marker}:file_content]")
+          end
+
+          def redact_absolute_paths(content, marker)
+            content.gsub(Privacy::ContentFilter::ABSOLUTE_PATH_PATTERN, marker)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,7 @@ require_relative "support/wild_skillops/fixtures"
 require_relative "support/wild_analyzers_permission/fixtures"
 require_relative "support/wild_analyzers_test_flakes/fixtures"
 require_relative "support/wild_telemetry_collector/event_fixtures"
+require_relative "support/wild_telemetry_pipeline/fixtures"
 
 RSpec.configure do |config|
   config.include Wild::Hooks::TestSupport::HookFixtures
@@ -54,6 +55,7 @@ RSpec.configure do |config|
   config.include Wild::Analyzers::Permission::TestSupport::Fixtures
   config.include Wild::Analyzers::TestFlakes::TestSupport::Fixtures
   config.include Wild::Telemetry::Collector::TestSupport::EventFixtures
+  config.include Wild::Telemetry::Pipeline::TestSupport::TranscriptFixtures
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/support/wild_telemetry_pipeline/fixtures.rb
+++ b/spec/support/wild_telemetry_pipeline/fixtures.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ModuleLength, Metrics/MethodLength, Metrics/ParameterLists
+
+require "json"
+require "time"
+
+module Wild
+  module Telemetry
+    module Pipeline
+      module TestSupport
+        module TranscriptFixtures
+          BASE_TIMESTAMP = Time.utc(2026, 3, 19, 14, 0, 0)
+
+          module_function
+
+          # ---- Claude Code JSONL ----
+
+          def claude_code_jsonl(entries: nil)
+            entries ||= default_claude_code_entries
+            entries.map { |e| JSON.generate(e) }.join("\n")
+          end
+
+          def default_claude_code_entries
+            [
+              {
+                "type" => "human",
+                "message" => "Can you check the database connection pool?",
+                "timestamp" => BASE_TIMESTAMP.iso8601
+              },
+              {
+                "type" => "assistant",
+                "message" => "I'll look into that. Let me use the inspect_connection tool...",
+                "timestamp" => (BASE_TIMESTAMP + 5).iso8601
+              },
+              {
+                "type" => "tool_use",
+                "name" => "inspect_connection",
+                "input" => {},
+                "timestamp" => (BASE_TIMESTAMP + 6).iso8601
+              },
+              {
+                "type" => "tool_result",
+                "name" => "inspect_connection",
+                "output" => "Pool size: 5, active: 3",
+                "timestamp" => (BASE_TIMESTAMP + 7).iso8601
+              }
+            ]
+          end
+
+          # ---- MCP log JSON ----
+
+          def mcp_log_json(messages: nil)
+            messages ||= default_mcp_messages
+            JSON.generate(messages)
+          end
+
+          def default_mcp_messages
+            [
+              {
+                "jsonrpc" => "2.0",
+                "method" => "tools/call",
+                "params" => { "name" => "inspect_routes", "arguments" => {} },
+                "id" => 1
+              },
+              {
+                "jsonrpc" => "2.0",
+                "result" => { "content" => [{ "type" => "text", "text" => "Found 42 routes" }] },
+                "id" => 1
+              }
+            ]
+          end
+
+          # ---- Generic JSON ----
+
+          def generic_json(turns: nil)
+            turns ||= default_generic_turns
+            JSON.generate({ "turns" => turns })
+          end
+
+          def default_generic_turns
+            [
+              { "role" => "user", "content" => "Show me the routes" },
+              { "role" => "assistant", "content" => "Let me check..." }
+            ]
+          end
+
+          # ---- Model builders ----
+
+          def make_turn(role: :user, content: "Hello", timestamp: nil, metadata: {})
+            Wild::Telemetry::Pipeline::Models::Turn.new(
+              role: role,
+              content: content,
+              timestamp: timestamp || BASE_TIMESTAMP,
+              metadata: metadata
+            )
+          end
+
+          def make_intent(description: "Testing intent", confidence: 0.75, source_turn_index: 0)
+            Wild::Telemetry::Pipeline::Models::Intent.new(
+              description: description,
+              confidence: confidence,
+              source_turn_index: source_turn_index
+            )
+          end
+
+          def make_tool_reference(name: "inspect_connection", action: :called, outcome: :success, turn_index: 1)
+            Wild::Telemetry::Pipeline::Models::ToolReference.new(
+              name: name,
+              action: action,
+              outcome: outcome,
+              turn_index: turn_index
+            )
+          end
+
+          def make_transcript(source_type: :generic, source_id: "test-001", turns: nil,
+                              intents: [], tool_references: [], metadata: {})
+            turns ||= [
+              make_turn(role: :user, content: "Hello"),
+              make_turn(role: :assistant, content: "Hi there!")
+            ]
+            Wild::Telemetry::Pipeline::Models::Transcript.new(
+              source_type: source_type,
+              source_id: source_id,
+              turns: turns,
+              intents: intents,
+              tool_references: tool_references,
+              metadata: metadata,
+              created_at: BASE_TIMESTAMP
+            )
+          end
+
+          def make_transcript_batch(count: 2)
+            transcripts = count.times.map do |i|
+              make_transcript(source_id: "batch-#{i + 1}")
+            end
+            Wild::Telemetry::Pipeline::Models::TranscriptBatch.new(
+              transcripts: transcripts,
+              metadata: { batch_id: "test-batch" },
+              created_at: BASE_TIMESTAMP
+            )
+          end
+
+          def turns_with_sensitive_content
+            [
+              make_turn(role: :user, content: "My email is user@example.com"),
+              make_turn(role: :assistant, content: "API key: api_key=sk-abc123def456ghi789jkl"),
+              make_turn(role: :user, content: "The path is /home/user/secrets/config.yml"),
+              make_turn(role: :assistant, content: "AWS key: AKIAIOSFODNN7EXAMPLE")
+            ]
+          end
+
+          def turns_with_intents
+            [
+              make_turn(role: :user, content: "I need to find all failing tests"),
+              make_turn(role: :assistant, content: "Let me check the test results for you"),
+              make_turn(role: :assistant, content: "I can't find a tool for running tests directly"),
+              make_turn(role: :user, content: "There must be a way to do this")
+            ]
+          end
+
+          def turns_with_tool_calls
+            [
+              make_turn(role: :user, content: "Check the routes"),
+              make_turn(role: :assistant, content: "[tool_use] inspect_routes({})"),
+              make_turn(role: :tool, content: "[tool_result:inspect_routes] Found 42 routes"),
+              make_turn(role: :assistant, content: "The app has 42 routes. Also mcp://list_resources is available.")
+            ]
+          end
+        end
+      end
+    end
+  end
+end
+
+# rubocop:enable Metrics/ModuleLength, Metrics/MethodLength, Metrics/ParameterLists

--- a/spec/wild/configuration_spec.rb
+++ b/spec/wild/configuration_spec.rb
@@ -107,6 +107,20 @@ RSpec.describe Wild::Configuration do
       expect(telemetry.pipeline.sequence_strategy).to eq(:ingest_order)
     end
 
+    # Transcript-pipeline knobs carried from the old wild-transcript-pipeline
+    # gem (Role 5 PR-9). Defaults preserved verbatim.
+    # One cohesive defaults check across the 7 carried knobs — splitting into
+    # 7 examples would be vanity granularity (F3).
+    it "Pipeline carries the transcript knobs with their old-gem defaults" do # rubocop:disable RSpec/MultipleExpectations
+      expect(telemetry.pipeline.intent_confidence_threshold).to eq(0.5)
+      expect(telemetry.pipeline.max_turn_content_length).to eq(10_000)
+      expect(telemetry.pipeline.max_turns_per_transcript).to eq(1_000)
+      expect(telemetry.pipeline.redaction_marker).to eq("[REDACTED]")
+      expect(telemetry.pipeline.strip_absolute_paths).to be(true)
+      expect(telemetry.pipeline.strip_file_contents).to be(true)
+      expect(telemetry.pipeline.custom_patterns).to eq([])
+    end
+
     it "Analysis defaults gap_threshold to 0.7" do
       expect(telemetry.analysis.gap_threshold).to eq(0.7)
     end

--- a/spec/wild/telemetry/pipeline/adversarial/edge_cases_spec.rb
+++ b/spec/wild/telemetry/pipeline/adversarial/edge_cases_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+
+RSpec.describe "Edge cases" do
+  describe "Configuration edge cases" do
+    it "supports multiple custom patterns simultaneously" do
+      Wild.configure do |c|
+        c.telemetry.pipeline.custom_patterns = [/PATTERN_A/, /PATTERN_B/]
+      end
+      redactor = Wild::Telemetry::Pipeline::Privacy::Redactor.new
+      result = redactor.redact_content("has PATTERN_A and PATTERN_B",
+                                       config: Wild.config.telemetry.pipeline)
+      expect(result).not_to include("PATTERN_A")
+      expect(result).not_to include("PATTERN_B")
+    end
+
+    it "supports very low intent threshold (0.0)" do
+      Wild.configure { |c| c.telemetry.pipeline.intent_confidence_threshold = 0.0 }
+      detector = Wild::Telemetry::Pipeline::Normalization::IntentDetector.new
+      turns = [make_turn(role: :user, content: "I need to do something")]
+      intents = detector.detect(turns, config: Wild.config.telemetry.pipeline)
+      expect(intents).not_to be_empty
+    end
+
+    it "supports very high threshold (1.0) producing no intents for normal text" do
+      Wild.configure { |c| c.telemetry.pipeline.intent_confidence_threshold = 1.0 }
+      detector = Wild::Telemetry::Pipeline::Normalization::IntentDetector.new
+      turns = [make_turn(role: :user, content: "I need to do something")]
+      intents = detector.detect(turns, config: Wild.config.telemetry.pipeline)
+      expect(intents).to be_empty
+    end
+
+    it "reset_configuration! restores all defaults" do
+      Wild.configure { |c| c.telemetry.pipeline.redaction_marker = "***" }
+      Wild.reset_config!
+      expect(Wild.config.telemetry.pipeline.redaction_marker).to eq("[REDACTED]")
+    end
+  end
+
+  describe "Turn edge cases" do
+    it "allows empty string content" do
+      t = Wild::Telemetry::Pipeline::Models::Turn.new(role: :user, content: "")
+      expect(t.content).to eq("")
+    end
+
+    it "handles content with newlines and special chars" do
+      content = "Line 1\nLine 2\t\rLine 3"
+      t = Wild::Telemetry::Pipeline::Models::Turn.new(role: :user, content: content)
+      expect(t.content).to eq(content)
+    end
+
+    it "handles unicode content" do
+      content = "日本語テスト 🚀 emoji"
+      t = Wild::Telemetry::Pipeline::Models::Turn.new(role: :user, content: content)
+      expect(t.content).to eq(content)
+    end
+  end
+
+  describe "TurnNormalizer edge cases" do
+    let(:normalizer) { Wild::Telemetry::Pipeline::Normalization::TurnNormalizer.new }
+
+    it "handles single-character content at the exact limit" do
+      Wild.configure { |c| c.telemetry.pipeline.max_turn_content_length = 1 }
+      turns = [make_turn(content: "a")]
+      result = normalizer.normalize(turns, config: Wild.config.telemetry.pipeline)
+      expect(result.first.content).to eq("a")
+    end
+
+    it "truncates at exact limit boundary" do
+      Wild.configure { |c| c.telemetry.pipeline.max_turn_content_length = 5 }
+      turns = [make_turn(content: "abcdef")]
+      result = normalizer.normalize(turns, config: Wild.config.telemetry.pipeline)
+      expect(result.first.content).to eq("abcde")
+    end
+  end
+
+  describe "ToolExtractor edge cases" do
+    let(:extractor) { Wild::Telemetry::Pipeline::Normalization::ToolExtractor.new }
+
+    it "handles turns with no content gracefully" do
+      turns = [make_turn(role: :assistant, content: "")]
+      expect(extractor.extract(turns)).to be_empty
+    end
+
+    it "handles multiple mcp:// references in one turn" do
+      content = "Use mcp://tool_a and mcp://tool_b together"
+      turns = [make_turn(role: :assistant, content: content)]
+      refs = extractor.extract(turns)
+      names = refs.map(&:name)
+      expect(names).to include("tool_a", "tool_b")
+    end
+
+    it "assigns correct indices across multiple turns" do
+      turns = [
+        make_turn(role: :user, content: "Check routes"),
+        make_turn(role: :assistant, content: "[tool_use] inspect_routes({})"),
+        make_turn(role: :tool, content: "[tool_result:inspect_routes] 42 routes")
+      ]
+      refs = extractor.extract(turns)
+      indices = refs.map(&:turn_index).uniq.sort
+      expect(indices).to all(be >= 0)
+    end
+  end
+
+  describe "IntentDetector edge cases" do
+    let(:detector) { Wild::Telemetry::Pipeline::Normalization::IntentDetector.new }
+
+    it "handles turns array with system turns" do
+      turns = [make_turn(role: :system, content: "I need to configure everything")]
+      intents = detector.detect(turns)
+      expect(intents).to be_empty
+    end
+
+    it "handles very long turn content" do
+      content = "I need to #{" do something " * 500}now"
+      turns = [make_turn(role: :user, content: content)]
+      expect { detector.detect(turns) }.not_to raise_error
+    end
+  end
+
+  describe "Export edge cases" do
+    let(:json_exporter) { Wild::Telemetry::Pipeline::Export::JsonExporter.new }
+    let(:md_exporter) { Wild::Telemetry::Pipeline::Export::MarkdownExporter.new }
+
+    it "JSON exporter handles transcript with many tool references" do
+      refs = 20.times.map do |i|
+        make_tool_reference(name: "tool_#{i}", turn_index: i)
+      end
+      t = make_transcript(tool_references: refs)
+      output = json_exporter.export([t])
+      parsed = JSON.parse(output)
+      expect(parsed["transcripts"].first["tool_reference_count"]).to eq(20)
+    end
+
+    it "Markdown exporter handles transcript with many intents" do
+      intents = 10.times.map do |i|
+        make_intent(description: "Intent #{i}", source_turn_index: i)
+      end
+      t = make_transcript(intents: intents)
+      output = md_exporter.export([t])
+      expect(output).to include("Intent 0")
+      expect(output).to include("Intent 9")
+    end
+
+    it "Markdown exporter handles turns with special markdown characters" do
+      turn = make_turn(content: "**bold** and _italic_ and `code` and [link](url)")
+      t = make_transcript(turns: [turn])
+      expect { md_exporter.export([t]) }.not_to raise_error
+    end
+  end
+
+  describe "TranscriptBatch edge cases" do
+    it "handles empty batch for summary counts" do
+      batch = Wild::Telemetry::Pipeline::Models::TranscriptBatch.new(transcripts: [])
+      expect(batch.total_turns).to eq(0)
+      expect(batch.total_intents).to eq(0)
+      expect(batch.total_tool_references).to eq(0)
+      expect(batch.source_types).to be_empty
+    end
+
+    it "computes source_types from mixed adapters" do
+      t1 = make_transcript(source_type: :claude_code, source_id: "a")
+      t2 = make_transcript(source_type: :mcp_log, source_id: "b")
+      t3 = make_transcript(source_type: :generic, source_id: "c")
+      batch = Wild::Telemetry::Pipeline::Models::TranscriptBatch.new(transcripts: [t1, t2, t3])
+      expect(batch.source_types).to match_array(%i[claude_code mcp_log generic])
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass

--- a/spec/wild/telemetry/pipeline/adversarial/malformed_input_spec.rb
+++ b/spec/wild/telemetry/pipeline/adversarial/malformed_input_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+
+RSpec.describe "Malformed input handling" do
+  let(:claude_adapter) { Wild::Telemetry::Pipeline::Ingestion::ClaudeCodeAdapter.new }
+  let(:mcp_adapter) { Wild::Telemetry::Pipeline::Ingestion::McpLogAdapter.new }
+  let(:generic_adapter) { Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new }
+
+  describe "ClaudeCodeAdapter" do
+    it "raises IngestionError for nil" do
+      expect { claude_adapter.parse(nil) }.to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for empty string" do
+      expect { claude_adapter.parse("") }.to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for whitespace only" do
+      expect { claude_adapter.parse("   ") }.to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "skips lines that are valid JSON but not objects" do
+      input = "42\n#{JSON.generate({ "type" => "human", "message" => "hi" })}"
+      result = claude_adapter.parse(input)
+      expect(result.first.turns.size).to eq(1)
+    end
+
+    it "skips truncated JSON lines" do
+      input = "{\"type\": \"human\", \"mess\n#{JSON.generate({ "type" => "human", "message" => "hi" })}"
+      result = claude_adapter.parse(input)
+      expect(result.first.turns.size).to eq(1)
+    end
+
+    it "produces transcript with zero turns if all lines skip" do
+      input = "42\n\"string\"\nnull"
+      result = claude_adapter.parse(input)
+      expect(result.first.turns).to be_empty
+    end
+  end
+
+  describe "McpLogAdapter" do
+    it "raises IngestionError for nil" do
+      expect { mcp_adapter.parse(nil) }.to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for empty string" do
+      expect { mcp_adapter.parse("") }.to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for non-JSON" do
+      expect { mcp_adapter.parse("not json") }.to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for JSON object instead of array" do
+      expect { mcp_adapter.parse('{"key": "value"}') }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "handles empty array gracefully" do
+      result = mcp_adapter.parse("[]")
+      expect(result.first.turns).to be_empty
+    end
+
+    it "skips non-Hash entries in the array" do
+      data = JSON.generate([nil, 42, "string", { "jsonrpc" => "2.0", "method" => "tools/call",
+                                                 "params" => { "name" => "foo" }, "id" => 1 },
+                            { "jsonrpc" => "2.0", "result" => {}, "id" => 1 }])
+      result = mcp_adapter.parse(data)
+      expect(result.first.turns).not_to be_empty
+    end
+
+    it "handles truncated JSON" do
+      expect { mcp_adapter.parse('[{"method": "tools') }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+  end
+
+  describe "GenericAdapter" do
+    it "raises IngestionError for nil" do
+      expect { generic_adapter.parse(nil) }.to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for non-JSON string" do
+      expect { generic_adapter.parse("just plain text") }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for JSON without turns/messages/array structure" do
+      expect { generic_adapter.parse('{"count": 10}') }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for JSON with turns key but non-array value" do
+      expect { generic_adapter.parse('{"turns": "not an array"}') }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "skips non-Hash entries in turns array" do
+      data = JSON.generate({ "turns" => [nil, 42, { "role" => "user", "content" => "hi" }] })
+      result = generic_adapter.parse(data)
+      expect(result.first.turns.size).to eq(1)
+    end
+
+    it "handles completely empty turns array" do
+      data = JSON.generate({ "turns" => [] })
+      result = generic_adapter.parse(data)
+      expect(result.first.turns).to be_empty
+    end
+  end
+
+  describe "Redactor edge cases" do
+    let(:redactor) { Wild::Telemetry::Pipeline::Privacy::Redactor.new }
+
+    it "handles nil content gracefully in redact_content" do
+      expect(redactor.redact_content(nil)).to eq(nil.to_s)
+    end
+
+    it "handles content with only whitespace" do
+      expect(redactor.redact_content("   ")).to eq("   ")
+    end
+
+    it "handles very long content" do
+      long = "x" * 50_000
+      expect { redactor.redact_content(long) }.not_to raise_error
+    end
+
+    it "handles content with unicode characters" do
+      content = "Email: user@example.com — café résumé"
+      result = redactor.redact_content(content)
+      expect(result).not_to include("user@example.com")
+      expect(result).to include("café")
+    end
+  end
+
+  describe "ContentFilter edge cases" do
+    let(:filter) { Wild::Telemetry::Pipeline::Privacy::ContentFilter.new }
+
+    it "handles nil gracefully" do
+      expect(filter.sensitive?(nil)).to be(false)
+    end
+
+    it "handles very long clean content" do
+      long = "The quick brown fox jumped over the lazy dog. " * 1000
+      expect { filter.sensitive?(long) }.not_to raise_error
+    end
+
+    it "handles content with embedded null bytes" do
+      expect { filter.sensitive?("hello\x00world") }.not_to raise_error
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass

--- a/spec/wild/telemetry/pipeline/export/json_exporter_spec.rb
+++ b/spec/wild/telemetry/pipeline/export/json_exporter_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Export::JsonExporter do
+  subject(:exporter) { described_class.new }
+
+  let(:transcripts) { [make_transcript, make_transcript(source_id: "test-002")] }
+
+  describe "#export" do
+    it "returns a JSON string" do
+      result = exporter.export(transcripts)
+      expect(result).to be_a(String)
+      expect { JSON.parse(result) }.not_to raise_error
+    end
+
+    it "includes metadata section" do
+      parsed = JSON.parse(exporter.export(transcripts))
+      expect(parsed).to have_key("metadata")
+    end
+
+    it "includes generated_at in metadata" do
+      parsed = JSON.parse(exporter.export(transcripts))
+      expect(parsed["metadata"]).to have_key("generated_at")
+    end
+
+    it "includes version in metadata" do
+      parsed = JSON.parse(exporter.export(transcripts))
+      # F1 — one gem-level version constant; the old per-gem VERSION was deleted.
+      expect(parsed["metadata"]["version"]).to eq(Wild::VERSION)
+    end
+
+    it "includes schema_version in metadata" do
+      parsed = JSON.parse(exporter.export(transcripts))
+      expect(parsed["metadata"]["schema_version"]).to eq("1.0")
+    end
+
+    it "includes summary section" do
+      parsed = JSON.parse(exporter.export(transcripts))
+      expect(parsed).to have_key("summary")
+    end
+
+    it "reports correct transcript_count in summary" do
+      parsed = JSON.parse(exporter.export(transcripts))
+      expect(parsed["summary"]["transcript_count"]).to eq(2)
+    end
+
+    it "reports correct total_turns in summary" do
+      parsed = JSON.parse(exporter.export(transcripts))
+      expected = transcripts.sum(&:turn_count)
+      expect(parsed["summary"]["total_turns"]).to eq(expected)
+    end
+
+    it "includes transcripts array" do
+      parsed = JSON.parse(exporter.export(transcripts))
+      expect(parsed["transcripts"].size).to eq(2)
+    end
+
+    it "exports empty array cleanly" do
+      parsed = JSON.parse(exporter.export([]))
+      expect(parsed["summary"]["transcript_count"]).to eq(0)
+      expect(parsed["transcripts"]).to eq([])
+    end
+
+    it "merges provided metadata into output" do
+      parsed = JSON.parse(exporter.export(transcripts, metadata: { source: "test_run" }))
+      expect(parsed["metadata"]["source"]).to eq("test_run")
+    end
+
+    it "raises ExportError for non-Array input" do
+      expect { exporter.export("bad") }
+        .to raise_error(Wild::Telemetry::Pipeline::ExportError)
+    end
+  end
+
+  describe "#export_batch" do
+    it "exports a TranscriptBatch" do
+      batch = make_transcript_batch(count: 2)
+      result = exporter.export_batch(batch)
+      parsed = JSON.parse(result)
+      expect(parsed["summary"]["transcript_count"]).to eq(2)
+    end
+
+    it "raises ExportError for non-Batch input" do
+      expect { exporter.export_batch("bad") }
+        .to raise_error(Wild::Telemetry::Pipeline::ExportError)
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/export/markdown_exporter_spec.rb
+++ b/spec/wild/telemetry/pipeline/export/markdown_exporter_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Export::MarkdownExporter do
+  subject(:exporter) { described_class.new }
+
+  let(:transcripts) { [make_transcript, make_transcript(source_id: "test-002")] }
+
+  describe "#export" do
+    it "returns a String" do
+      expect(exporter.export(transcripts)).to be_a(String)
+    end
+
+    it "starts with a top-level heading" do
+      expect(exporter.export(transcripts)).to start_with("# Transcript Export")
+    end
+
+    it "includes generated timestamp" do
+      expect(exporter.export(transcripts)).to include("Generated")
+    end
+
+    it "includes transcript count" do
+      expect(exporter.export(transcripts)).to include("Transcripts:** 2")
+    end
+
+    it "includes total turns" do
+      output = exporter.export(transcripts)
+      expect(output).to include("Total Turns")
+    end
+
+    it "includes a section for each transcript" do
+      output = exporter.export(transcripts)
+      expect(output).to include("test-001")
+      expect(output).to include("test-002")
+    end
+
+    it "includes turns section" do
+      output = exporter.export(transcripts)
+      expect(output).to include("### Turns")
+    end
+
+    it 'labels user turns with "User"' do
+      output = exporter.export(transcripts)
+      expect(output).to include("**[0] User**")
+    end
+
+    it 'labels assistant turns with "Assistant"' do
+      turns = [make_turn(role: :assistant, content: "Hi there")]
+      t = make_transcript(turns: turns)
+      output = exporter.export([t])
+      expect(output).to include("**[0] Assistant**")
+    end
+
+    it "includes intents section when intents present" do
+      t = make_transcript(intents: [make_intent(description: "Check connection")])
+      output = exporter.export([t])
+      expect(output).to include("### Detected Intents")
+      expect(output).to include("Check connection")
+    end
+
+    it "includes tool references section when refs present" do
+      t = make_transcript(tool_references: [make_tool_reference])
+      output = exporter.export([t])
+      expect(output).to include("### Tool References")
+      expect(output).to include("inspect_connection")
+    end
+
+    it "shows no intents section when none present" do
+      output = exporter.export(transcripts)
+      expect(output).not_to include("### Detected Intents")
+    end
+
+    it "handles empty transcripts array" do
+      output = exporter.export([])
+      expect(output).to include("_No transcripts found._")
+    end
+
+    it "includes metadata when provided" do
+      output = exporter.export(transcripts, metadata: { run_id: "abc" })
+      expect(output).to include("run_id=abc")
+    end
+
+    it "shows _empty_ for turns with empty content" do
+      turn = make_turn(content: "")
+      t = make_transcript(turns: [turn])
+      output = exporter.export([t])
+      expect(output).to include("_empty_")
+    end
+
+    it "raises ExportError for non-Array input" do
+      expect { exporter.export("bad") }
+        .to raise_error(Wild::Telemetry::Pipeline::ExportError)
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/ingestion/claude_code_adapter_spec.rb
+++ b/spec/wild/telemetry/pipeline/ingestion/claude_code_adapter_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Ingestion::ClaudeCodeAdapter do
+  subject(:adapter) { described_class.new }
+
+  let(:jsonl) { claude_code_jsonl }
+
+  describe "#parse" do
+    it "returns an array of Transcript objects" do
+      result = adapter.parse(jsonl)
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Wild::Telemetry::Pipeline::Models::Transcript))
+    end
+
+    it "returns a single transcript" do
+      expect(adapter.parse(jsonl).size).to eq(1)
+    end
+
+    it "sets source_type to :claude_code" do
+      expect(adapter.parse(jsonl).first.source_type).to eq(:claude_code)
+    end
+
+    it "uses provided source_id" do
+      result = adapter.parse(jsonl, source_id: "session-abc")
+      expect(result.first.source_id).to eq("session-abc")
+    end
+
+    it "generates a source_id when not provided" do
+      result = adapter.parse(jsonl)
+      expect(result.first.source_id).not_to be_empty
+    end
+
+    it "parses human entries as :user turns" do
+      result = adapter.parse(jsonl)
+      user_turns = result.first.turns.select(&:user_turn?)
+      expect(user_turns).not_to be_empty
+    end
+
+    it "parses assistant entries as :assistant turns" do
+      result = adapter.parse(jsonl)
+      assistant_turns = result.first.turns.select(&:assistant_turn?)
+      expect(assistant_turns).not_to be_empty
+    end
+
+    it "parses tool_use entries as :tool turns" do
+      result = adapter.parse(jsonl)
+      tool_turns = result.first.turns.select(&:tool_turn?)
+      expect(tool_turns).not_to be_empty
+    end
+
+    it "parses tool_result entries as :tool turns" do
+      result = adapter.parse(jsonl)
+      tool_turns = result.first.turns.select(&:tool_turn?)
+      expect(tool_turns.size).to eq(2)
+    end
+
+    it "preserves timestamps when present" do
+      result = adapter.parse(jsonl)
+      turns_with_ts = result.first.turns.reject { |t| t.timestamp.nil? }
+      expect(turns_with_ts).not_to be_empty
+    end
+
+    it "skips lines with unknown type" do
+      unknown = JSON.generate({ "type" => "unknown_event", "message" => "ignored" })
+      valid = JSON.generate({ "type" => "human", "message" => "hello" })
+      result = adapter.parse([unknown, valid].join("\n"))
+      expect(result.first.turns.size).to eq(1)
+    end
+
+    it "skips malformed JSON lines silently" do
+      valid = JSON.generate({ "type" => "human", "message" => "hello" })
+      result = adapter.parse("not json\n#{valid}")
+      expect(result.first.turns.size).to eq(1)
+    end
+
+    it "raises IngestionError for nil input" do
+      expect { adapter.parse(nil) }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for empty string" do
+      expect { adapter.parse("") }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for whitespace-only input" do
+      expect { adapter.parse("   ") }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "includes tool name in metadata for tool_use entries" do
+      result = adapter.parse(jsonl)
+      tool_use_turn = result.first.turns.find do |t|
+        t.tool_turn? && t.metadata[:tool_name] == "inspect_connection"
+      end
+      expect(tool_use_turn).not_to be_nil
+    end
+
+    it "formats tool_use content with tool name and input" do
+      result = adapter.parse(jsonl)
+      tool_turn = result.first.turns.find { |t| t.tool_turn? && t.metadata[:tool_name] }
+      expect(tool_turn.content).to include("inspect_connection")
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/ingestion/generic_adapter_spec.rb
+++ b/spec/wild/telemetry/pipeline/ingestion/generic_adapter_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Ingestion::GenericAdapter do
+  subject(:adapter) { described_class.new }
+
+  describe "#parse" do
+    context "with turns-keyed JSON" do
+      it "returns an array of Transcripts" do
+        result = adapter.parse(generic_json)
+        expect(result).to all(be_a(Wild::Telemetry::Pipeline::Models::Transcript))
+      end
+
+      it "sets source_type to :generic" do
+        expect(adapter.parse(generic_json).first.source_type).to eq(:generic)
+      end
+
+      it "parses user and assistant turns" do
+        result = adapter.parse(generic_json)
+        roles = result.first.turns.map(&:role)
+        expect(roles).to include(:user, :assistant)
+      end
+    end
+
+    context "with messages-keyed JSON" do
+      it "parses messages array" do
+        data = JSON.generate({ "messages" => default_generic_turns })
+        result = adapter.parse(data)
+        expect(result.first.turn_count).to eq(2)
+      end
+    end
+
+    context "with bare JSON array" do
+      it "parses array of turn objects" do
+        data = JSON.generate(default_generic_turns)
+        result = adapter.parse(data)
+        expect(result.first.turn_count).to eq(2)
+      end
+    end
+
+    context "with role aliases" do
+      it "maps human to :user" do
+        data = JSON.generate({ "turns" => [{ "role" => "human", "content" => "hi" }] })
+        result = adapter.parse(data)
+        expect(result.first.turns.first.role).to eq(:user)
+      end
+
+      it "maps ai to :assistant" do
+        data = JSON.generate({ "turns" => [{ "role" => "ai", "content" => "hi" }] })
+        result = adapter.parse(data)
+        expect(result.first.turns.first.role).to eq(:assistant)
+      end
+
+      it "maps bot to :assistant" do
+        data = JSON.generate({ "turns" => [{ "role" => "bot", "content" => "hi" }] })
+        result = adapter.parse(data)
+        expect(result.first.turns.first.role).to eq(:assistant)
+      end
+
+      it "maps function to :tool" do
+        data = JSON.generate({ "turns" => [{ "role" => "function", "content" => "result" }] })
+        result = adapter.parse(data)
+        expect(result.first.turns.first.role).to eq(:tool)
+      end
+    end
+
+    context "with timestamps" do
+      it "parses timestamp when present" do
+        ts = "2026-03-19T14:00:00Z"
+        data = JSON.generate({ "turns" => [{ "role" => "user", "content" => "hi", "timestamp" => ts }] })
+        result = adapter.parse(data)
+        expect(result.first.turns.first.timestamp).not_to be_nil
+      end
+    end
+
+    it "skips entries with unknown roles" do
+      data = JSON.generate({ "turns" => [
+                             { "role" => "robot", "content" => "beep" },
+                             { "role" => "user", "content" => "hi" }
+                           ] })
+      result = adapter.parse(data)
+      expect(result.first.turn_count).to eq(1)
+    end
+
+    it "skips non-Hash entries" do
+      data = JSON.generate({ "turns" => ["bad_string", nil, { "role" => "user", "content" => "hi" }] })
+      result = adapter.parse(data)
+      expect(result.first.turn_count).to eq(1)
+    end
+
+    it "uses provided source_id" do
+      result = adapter.parse(generic_json, source_id: "conv-42")
+      expect(result.first.source_id).to eq("conv-42")
+    end
+
+    it "raises IngestionError for nil input" do
+      expect { adapter.parse(nil) }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for invalid JSON" do
+      expect { adapter.parse("{broken") }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for JSON without turns or messages" do
+      expect { adapter.parse('{"count": 5}') }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for JSON object with non-array turns" do
+      expect { adapter.parse('{"turns": "bad"}') }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/ingestion/mcp_log_adapter_spec.rb
+++ b/spec/wild/telemetry/pipeline/ingestion/mcp_log_adapter_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Ingestion::McpLogAdapter do
+  subject(:adapter) { described_class.new }
+
+  let(:mcp_json) { mcp_log_json }
+
+  describe "#parse" do
+    it "returns an array of Transcript objects" do
+      result = adapter.parse(mcp_json)
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Wild::Telemetry::Pipeline::Models::Transcript))
+    end
+
+    it "returns a single transcript" do
+      expect(adapter.parse(mcp_json).size).to eq(1)
+    end
+
+    it "sets source_type to :mcp_log" do
+      expect(adapter.parse(mcp_json).first.source_type).to eq(:mcp_log)
+    end
+
+    it "uses provided source_id" do
+      result = adapter.parse(mcp_json, source_id: "mcp-session-1")
+      expect(result.first.source_id).to eq("mcp-session-1")
+    end
+
+    it "creates a turn for each request" do
+      result = adapter.parse(mcp_json)
+      user_turns = result.first.turns.select(&:user_turn?)
+      expect(user_turns).not_to be_empty
+    end
+
+    it "creates a tool turn for each response" do
+      result = adapter.parse(mcp_json)
+      tool_turns = result.first.turns.select(&:tool_turn?)
+      expect(tool_turns).not_to be_empty
+    end
+
+    it "includes tool name in request turn content" do
+      result = adapter.parse(mcp_json)
+      request_turn = result.first.turns.find(&:user_turn?)
+      expect(request_turn.content).to include("inspect_routes")
+    end
+
+    it "includes result text in response turn content" do
+      result = adapter.parse(mcp_json)
+      response_turn = result.first.turns.find(&:tool_turn?)
+      expect(response_turn.content).to include("Found 42 routes")
+    end
+
+    it "handles error responses" do
+      messages = [
+        { "jsonrpc" => "2.0", "method" => "tools/call",
+          "params" => { "name" => "bad_tool", "arguments" => {} }, "id" => 9 },
+        { "jsonrpc" => "2.0", "error" => { "code" => -32_601, "message" => "Method not found" }, "id" => 9 }
+      ]
+      result = adapter.parse(JSON.generate(messages))
+      error_turn = result.first.turns.find { |t| t.metadata[:mcp_error] }
+      expect(error_turn).not_to be_nil
+      expect(error_turn.content).to include("mcp:error")
+    end
+
+    it "skips non-Hash entries silently" do
+      messages = ["not a hash", { "jsonrpc" => "2.0", "method" => "tools/call",
+                                  "params" => { "name" => "foo" }, "id" => 1 },
+                  { "jsonrpc" => "2.0", "result" => { "content" => [] }, "id" => 1 }]
+      result = adapter.parse(JSON.generate(messages))
+      expect(result).not_to be_empty
+    end
+
+    it "raises IngestionError for nil input" do
+      expect { adapter.parse(nil) }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for invalid JSON" do
+      expect { adapter.parse("{broken json") }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "raises IngestionError for non-array JSON" do
+      expect { adapter.parse('{"key": "value"}') }
+        .to raise_error(Wild::Telemetry::Pipeline::IngestionError)
+    end
+
+    it "handles non-tools/call methods" do
+      messages = [
+        { "jsonrpc" => "2.0", "method" => "resources/list", "params" => {}, "id" => 5 },
+        { "jsonrpc" => "2.0", "result" => { "resources" => [] }, "id" => 5 }
+      ]
+      result = adapter.parse(JSON.generate(messages))
+      expect(result.first.turns).not_to be_empty
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/integration/cross_adapter_spec.rb
+++ b/spec/wild/telemetry/pipeline/integration/cross_adapter_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+
+RSpec.describe "Cross-adapter consistency" do
+  let(:json_exporter) { Wild::Telemetry::Pipeline::Export::JsonExporter.new }
+
+  it "all adapters produce Transcript with correct source_type" do
+    {
+      Wild::Telemetry::Pipeline::Ingestion::ClaudeCodeAdapter => [:claude_code, claude_code_jsonl],
+      Wild::Telemetry::Pipeline::Ingestion::McpLogAdapter => [:mcp_log, mcp_log_json],
+      Wild::Telemetry::Pipeline::Ingestion::GenericAdapter => [:generic, generic_json]
+    }.each do |adapter_class, (expected_type, input)|
+      transcripts = adapter_class.new.parse(input)
+      expect(transcripts.first.source_type).to eq(expected_type)
+    end
+  end
+
+  it "all adapters produce JSON-serializable transcripts" do
+    [
+      [Wild::Telemetry::Pipeline::Ingestion::ClaudeCodeAdapter.new, claude_code_jsonl],
+      [Wild::Telemetry::Pipeline::Ingestion::McpLogAdapter.new, mcp_log_json],
+      [Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new, generic_json]
+    ].each do |adapter, input|
+      transcripts = adapter.parse(input)
+      expect { json_exporter.export(transcripts) }.not_to raise_error
+    end
+  end
+
+  it "all adapters produce turns with valid roles" do
+    valid_roles = Wild::Telemetry::Pipeline::Models::Turn::VALID_ROLES
+    [
+      [Wild::Telemetry::Pipeline::Ingestion::ClaudeCodeAdapter.new, claude_code_jsonl],
+      [Wild::Telemetry::Pipeline::Ingestion::McpLogAdapter.new, mcp_log_json],
+      [Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new, generic_json]
+    ].each do |adapter, input|
+      transcripts = adapter.parse(input)
+      roles = transcripts.flat_map(&:turns).map(&:role)
+      expect(roles - valid_roles).to be_empty
+    end
+  end
+
+  it "all adapters produce non-empty turn content" do
+    [
+      [Wild::Telemetry::Pipeline::Ingestion::ClaudeCodeAdapter.new, claude_code_jsonl],
+      [Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new, generic_json]
+    ].each do |adapter, input|
+      transcripts = adapter.parse(input)
+      transcripts.flat_map(&:turns).each do |turn|
+        expect(turn.content).to be_a(String)
+      end
+    end
+  end
+
+  it "redactor preserves turn count across all adapter outputs" do
+    redactor = Wild::Telemetry::Pipeline::Privacy::Redactor.new
+    [
+      [Wild::Telemetry::Pipeline::Ingestion::ClaudeCodeAdapter.new, claude_code_jsonl],
+      [Wild::Telemetry::Pipeline::Ingestion::McpLogAdapter.new, mcp_log_json],
+      [Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new, generic_json]
+    ].each do |adapter, input|
+      transcripts = adapter.parse(input)
+      transcripts.each do |t|
+        redacted = redactor.redact_transcript(t)
+        expect(redacted.turn_count).to eq(t.turn_count)
+      end
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass

--- a/spec/wild/telemetry/pipeline/integration/full_pipeline_spec.rb
+++ b/spec/wild/telemetry/pipeline/integration/full_pipeline_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleMemoizedHelpers
+
+RSpec.describe "Full pipeline integration" do
+  let(:normalizer) { Wild::Telemetry::Pipeline::Normalization::TurnNormalizer.new }
+  let(:intent_detector) { Wild::Telemetry::Pipeline::Normalization::IntentDetector.new }
+  let(:tool_extractor) { Wild::Telemetry::Pipeline::Normalization::ToolExtractor.new }
+  let(:redactor) { Wild::Telemetry::Pipeline::Privacy::Redactor.new }
+  let(:json_exporter) { Wild::Telemetry::Pipeline::Export::JsonExporter.new }
+  let(:md_exporter) { Wild::Telemetry::Pipeline::Export::MarkdownExporter.new }
+
+  describe "Claude Code session pipeline" do
+    let(:jsonl) { claude_code_jsonl }
+    let(:adapter) { Wild::Telemetry::Pipeline::Ingestion::ClaudeCodeAdapter.new }
+
+    it "completes ingest -> normalize -> redact -> export without error" do
+      transcripts = adapter.parse(jsonl, source_id: "session-001")
+      normalized = transcripts.map { |t| normalizer.normalize(t.turns) }
+      redacted = normalized.map { |turns| turns.map { |turn| redactor.redact_turn(turn) } }
+      expect(redacted).not_to be_empty
+    end
+
+    it "produces valid JSON output" do
+      transcripts = Wild::Telemetry::Pipeline.process(jsonl, adapter: adapter, source_id: "session-001")
+      json = json_exporter.export(transcripts)
+      parsed = JSON.parse(json)
+      expect(parsed["summary"]["transcript_count"]).to eq(1)
+    end
+
+    it "produces non-empty markdown output" do
+      transcripts = Wild::Telemetry::Pipeline.process(jsonl, adapter: adapter)
+      md = md_exporter.export(transcripts)
+      expect(md).to include("# Transcript Export")
+      expect(md).to include("### Turns")
+    end
+
+    it "detects tool references for tool_use entries" do
+      transcripts = Wild::Telemetry::Pipeline.process(jsonl, adapter: adapter)
+      all_refs = transcripts.flat_map(&:tool_references)
+      expect(all_refs.map(&:name)).to include("inspect_connection")
+    end
+  end
+
+  describe "MCP log pipeline" do
+    let(:json) { mcp_log_json }
+    let(:adapter) { Wild::Telemetry::Pipeline::Ingestion::McpLogAdapter.new }
+
+    it "ingests and processes MCP logs" do
+      transcripts = Wild::Telemetry::Pipeline.process(json, adapter: adapter, source_id: "mcp-001")
+      expect(transcripts).to all(be_a(Wild::Telemetry::Pipeline::Models::Transcript))
+    end
+
+    it "produces exportable JSON" do
+      transcripts = Wild::Telemetry::Pipeline.process(json, adapter: adapter)
+      output = json_exporter.export(transcripts)
+      expect { JSON.parse(output) }.not_to raise_error
+    end
+
+    it "detects tool references from MCP requests" do
+      transcripts = Wild::Telemetry::Pipeline.process(json, adapter: adapter)
+      all_refs = transcripts.flat_map(&:tool_references)
+      expect(all_refs).not_to be_empty
+    end
+  end
+
+  describe "Generic conversation pipeline" do
+    let(:json) { generic_json }
+    let(:adapter) { Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new }
+
+    it "processes generic conversations end to end" do
+      transcripts = Wild::Telemetry::Pipeline.process(json, adapter: adapter)
+      expect(transcripts).not_to be_empty
+    end
+
+    it "strips sensitive content in generic conversations" do
+      turns = [
+        { "role" => "user", "content" => "My email is secret@corp.com" },
+        { "role" => "assistant", "content" => "Got it" }
+      ]
+      input = JSON.generate({ "turns" => turns })
+      transcripts = Wild::Telemetry::Pipeline.process(input, adapter: adapter)
+      content_values = transcripts.flat_map(&:turns).map(&:content)
+      expect(content_values.join).not_to include("secret@corp.com")
+    end
+  end
+
+  describe "Batch export" do
+    it "exports multiple transcripts as a batch" do
+      batch = make_transcript_batch(count: 3)
+      json = json_exporter.export_batch(batch)
+      parsed = JSON.parse(json)
+      expect(parsed["summary"]["transcript_count"]).to eq(3)
+    end
+  end
+
+  describe "Wild::Telemetry::Pipeline.process convenience method" do
+    it "returns Transcript objects" do
+      adapter = Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new
+      result = Wild::Telemetry::Pipeline.process(generic_json, adapter: adapter)
+      expect(result).to all(be_a(Wild::Telemetry::Pipeline::Models::Transcript))
+    end
+
+    it "marks transcripts as processed" do
+      adapter = Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new
+      result = Wild::Telemetry::Pipeline.process(generic_json, adapter: adapter)
+      expect(result.first.metadata[:processed]).to be(true)
+    end
+
+    it "applies custom config" do
+      adapter = Wild::Telemetry::Pipeline::Ingestion::GenericAdapter.new
+      Wild.configure do |c|
+        c.telemetry.pipeline.max_turns_per_transcript = 1
+      end
+      result = Wild::Telemetry::Pipeline.process(generic_json, adapter: adapter,
+                                                               config: Wild.config.telemetry.pipeline)
+      expect(result.first.turn_count).to be <= 1
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleMemoizedHelpers

--- a/spec/wild/telemetry/pipeline/models/intent_spec.rb
+++ b/spec/wild/telemetry/pipeline/models/intent_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Models::Intent do
+  subject(:intent) do
+    described_class.new(description: "Check database", confidence: 0.8, source_turn_index: 2)
+  end
+
+  describe "#initialize" do
+    it "stores description, confidence, and source_turn_index" do
+      expect(intent.description).to eq("Check database")
+      expect(intent.confidence).to eq(0.8)
+      expect(intent.source_turn_index).to eq(2)
+    end
+
+    it "coerces confidence to float" do
+      i = described_class.new(description: "test", confidence: 1, source_turn_index: 0)
+      expect(i.confidence).to be_a(Float)
+    end
+
+    it "accepts 0.0 confidence" do
+      i = described_class.new(description: "test", confidence: 0.0, source_turn_index: 0)
+      expect(i.confidence).to eq(0.0)
+    end
+
+    it "accepts 1.0 confidence" do
+      i = described_class.new(description: "test", confidence: 1.0, source_turn_index: 0)
+      expect(i.confidence).to eq(1.0)
+    end
+
+    it "raises ArgumentError for empty description" do
+      expect { described_class.new(description: "", confidence: 0.5, source_turn_index: 0) }
+        .to raise_error(ArgumentError, /description/)
+    end
+
+    it "raises ArgumentError for non-string description" do
+      expect { described_class.new(description: nil, confidence: 0.5, source_turn_index: 0) }
+        .to raise_error(ArgumentError, /description/)
+    end
+
+    it "raises ArgumentError for confidence above 1.0" do
+      expect { described_class.new(description: "test", confidence: 1.1, source_turn_index: 0) }
+        .to raise_error(ArgumentError, /confidence/)
+    end
+
+    it "raises ArgumentError for negative confidence" do
+      expect { described_class.new(description: "test", confidence: -0.1, source_turn_index: 0) }
+        .to raise_error(ArgumentError, /confidence/)
+    end
+
+    it "raises ArgumentError for negative source_turn_index" do
+      expect { described_class.new(description: "test", confidence: 0.5, source_turn_index: -1) }
+        .to raise_error(ArgumentError, /source_turn_index/)
+    end
+
+    it "raises ArgumentError for non-integer source_turn_index" do
+      expect { described_class.new(description: "test", confidence: 0.5, source_turn_index: 1.5) }
+        .to raise_error(ArgumentError, /source_turn_index/)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash with all fields" do
+      h = intent.to_h
+      expect(h[:description]).to eq("Check database")
+      expect(h[:confidence]).to eq(0.8)
+      expect(h[:source_turn_index]).to eq(2)
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/models/tool_reference_spec.rb
+++ b/spec/wild/telemetry/pipeline/models/tool_reference_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Models::ToolReference do
+  subject(:ref) do
+    described_class.new(name: "inspect_connection", action: :called, outcome: :success, turn_index: 3)
+  end
+
+  describe "#initialize" do
+    it "stores name, action, outcome, turn_index" do
+      expect(ref.name).to eq("inspect_connection")
+      expect(ref.action).to eq(:called)
+      expect(ref.outcome).to eq(:success)
+      expect(ref.turn_index).to eq(3)
+    end
+
+    it "accepts nil outcome" do
+      r = described_class.new(name: "some_tool", action: :mentioned, turn_index: 0)
+      expect(r.outcome).to be_nil
+    end
+
+    it "accepts all valid actions" do
+      described_class::VALID_ACTIONS.each do |action|
+        r = described_class.new(name: "tool", action: action, turn_index: 0)
+        expect(r.action).to eq(action)
+      end
+    end
+
+    it "coerces string action to symbol" do
+      r = described_class.new(name: "tool", action: "called", turn_index: 0)
+      expect(r.action).to eq(:called)
+    end
+
+    it "accepts all valid outcomes" do
+      described_class::VALID_OUTCOMES.each do |outcome|
+        r = described_class.new(name: "tool", action: :called, outcome: outcome, turn_index: 0)
+        expect(r.outcome).to eq(outcome)
+      end
+    end
+
+    it "raises ArgumentError for empty name" do
+      expect { described_class.new(name: "", action: :called, turn_index: 0) }
+        .to raise_error(ArgumentError, /name/)
+    end
+
+    it "raises ArgumentError for invalid action" do
+      expect { described_class.new(name: "tool", action: :unknown_action, turn_index: 0) }
+        .to raise_error(ArgumentError, /action/)
+    end
+
+    it "raises ArgumentError for invalid outcome" do
+      expect { described_class.new(name: "tool", action: :called, outcome: :bad, turn_index: 0) }
+        .to raise_error(ArgumentError, /outcome/)
+    end
+
+    it "raises ArgumentError for negative turn_index" do
+      expect { described_class.new(name: "tool", action: :called, turn_index: -1) }
+        .to raise_error(ArgumentError, /turn_index/)
+    end
+
+    it "raises ArgumentError for non-integer turn_index" do
+      expect { described_class.new(name: "tool", action: :called, turn_index: 1.0) }
+        .to raise_error(ArgumentError, /turn_index/)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a complete hash" do
+      h = ref.to_h
+      expect(h[:name]).to eq("inspect_connection")
+      expect(h[:action]).to eq(:called)
+      expect(h[:outcome]).to eq(:success)
+      expect(h[:turn_index]).to eq(3)
+    end
+
+    it "includes nil outcome in hash" do
+      r = described_class.new(name: "tool", action: :mentioned, turn_index: 0)
+      expect(r.to_h[:outcome]).to be_nil
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/models/transcript_batch_spec.rb
+++ b/spec/wild/telemetry/pipeline/models/transcript_batch_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Models::TranscriptBatch do
+  subject(:batch) { make_transcript_batch(count: 3) }
+
+  describe "#initialize" do
+    it "stores transcripts as frozen array" do
+      expect(batch.transcripts).to be_frozen
+    end
+
+    it "stores metadata as frozen hash" do
+      expect(batch.metadata).to be_frozen
+    end
+
+    it "defaults created_at to current time" do
+      b = described_class.new
+      expect(b.created_at).to be_a(Time)
+    end
+
+    it "raises ArgumentError for non-Array transcripts" do
+      expect { described_class.new(transcripts: "bad") }
+        .to raise_error(ArgumentError, /transcripts/)
+    end
+
+    it "raises ArgumentError for non-Hash metadata" do
+      expect { described_class.new(metadata: "bad") }
+        .to raise_error(ArgumentError, /metadata/)
+    end
+  end
+
+  describe "#size" do
+    it "returns the number of transcripts" do
+      expect(batch.size).to eq(3)
+    end
+  end
+
+  describe "#empty?" do
+    it "returns false for non-empty batch" do
+      expect(batch.empty?).to be(false)
+    end
+
+    it "returns true for empty batch" do
+      b = described_class.new(transcripts: [])
+      expect(b.empty?).to be(true)
+    end
+  end
+
+  describe "#total_turns" do
+    it "sums turns across all transcripts" do
+      expect(batch.total_turns).to eq(batch.transcripts.sum(&:turn_count))
+    end
+  end
+
+  describe "#total_intents" do
+    it "returns 0 when no intents" do
+      expect(batch.total_intents).to eq(0)
+    end
+  end
+
+  describe "#total_tool_references" do
+    it "returns 0 when no tool references" do
+      expect(batch.total_tool_references).to eq(0)
+    end
+  end
+
+  describe "#source_types" do
+    it "returns unique source types" do
+      expect(batch.source_types).to eq([:generic])
+    end
+  end
+
+  describe "#to_h" do
+    it "includes all summary keys" do
+      h = batch.to_h
+      expect(h).to include(:created_at, :transcript_count, :total_turns,
+                           :total_intents, :total_tool_references, :source_types,
+                           :metadata, :transcripts)
+    end
+
+    it "transcript_count matches size" do
+      expect(batch.to_h[:transcript_count]).to eq(3)
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/models/transcript_spec.rb
+++ b/spec/wild/telemetry/pipeline/models/transcript_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Models::Transcript do
+  subject(:transcript) { make_transcript }
+
+  describe "#initialize" do
+    it "stores source_type as symbol" do
+      expect(transcript.source_type).to eq(:generic)
+    end
+
+    it "stores source_id as frozen string" do
+      expect(transcript.source_id).to eq("test-001")
+      expect(transcript.source_id).to be_frozen
+    end
+
+    it "freezes turns array" do
+      expect(transcript.turns).to be_frozen
+    end
+
+    it "freezes intents array" do
+      expect(transcript.intents).to be_frozen
+    end
+
+    it "freezes tool_references array" do
+      expect(transcript.tool_references).to be_frozen
+    end
+
+    it "freezes metadata hash" do
+      expect(transcript.metadata).to be_frozen
+    end
+
+    it "defaults created_at to current time when nil" do
+      t = described_class.new(source_type: :generic, source_id: "x")
+      expect(t.created_at).to be_a(Time)
+    end
+
+    it "raises ArgumentError for non-Symbol source_type" do
+      expect do
+        described_class.new(source_type: "generic", source_id: "x")
+      end.to raise_error(ArgumentError, /source_type/)
+    end
+
+    it "raises ArgumentError for empty source_id" do
+      expect do
+        described_class.new(source_type: :generic, source_id: "")
+      end.to raise_error(ArgumentError, /source_id/)
+    end
+
+    it "raises ArgumentError for non-Array turns" do
+      expect do
+        described_class.new(source_type: :generic, source_id: "x", turns: "bad")
+      end.to raise_error(ArgumentError, /turns/)
+    end
+
+    it "raises ArgumentError for non-Hash metadata" do
+      expect do
+        described_class.new(source_type: :generic, source_id: "x", metadata: [])
+      end.to raise_error(ArgumentError, /metadata/)
+    end
+  end
+
+  describe "#turn_count" do
+    it "returns the number of turns" do
+      expect(transcript.turn_count).to eq(2)
+    end
+  end
+
+  describe "#intent_count" do
+    it "returns 0 when no intents" do
+      expect(transcript.intent_count).to eq(0)
+    end
+
+    it "returns count when intents present" do
+      t = make_transcript(intents: [make_intent])
+      expect(t.intent_count).to eq(1)
+    end
+  end
+
+  describe "#tool_reference_count" do
+    it "returns 0 when no tool references" do
+      expect(transcript.tool_reference_count).to eq(0)
+    end
+
+    it "returns count when tool refs present" do
+      t = make_transcript(tool_references: [make_tool_reference])
+      expect(t.tool_reference_count).to eq(1)
+    end
+  end
+
+  describe "#to_h" do
+    it "includes all top-level keys" do
+      h = transcript.to_h
+      expect(h).to include(:source_type, :source_id, :created_at, :turn_count,
+                           :intent_count, :tool_reference_count, :turns, :intents,
+                           :tool_references, :metadata)
+    end
+
+    it "serializes created_at as iso8601 string" do
+      expect(transcript.to_h[:created_at]).to be_a(String)
+    end
+
+    it "serializes turns as array of hashes" do
+      expect(transcript.to_h[:turns]).to all(be_a(Hash))
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/models/turn_spec.rb
+++ b/spec/wild/telemetry/pipeline/models/turn_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Models::Turn do
+  subject(:turn) { described_class.new(role: :user, content: "Hello world") }
+
+  describe "#initialize" do
+    it "stores role as symbol" do
+      expect(turn.role).to eq(:user)
+    end
+
+    it "stores content as frozen string" do
+      expect(turn.content).to eq("Hello world")
+      expect(turn.content).to be_frozen
+    end
+
+    it "accepts all valid roles" do
+      described_class::VALID_ROLES.each do |role|
+        t = described_class.new(role: role, content: "test")
+        expect(t.role).to eq(role)
+      end
+    end
+
+    it "coerces string roles to symbols" do
+      t = described_class.new(role: "assistant", content: "hi")
+      expect(t.role).to eq(:assistant)
+    end
+
+    it "accepts nil timestamp" do
+      t = described_class.new(role: :user, content: "hi")
+      expect(t.timestamp).to be_nil
+    end
+
+    it "stores timestamp when provided" do
+      ts = Time.utc(2026, 1, 1)
+      t = described_class.new(role: :user, content: "hi", timestamp: ts)
+      expect(t.timestamp).to eq(ts)
+    end
+
+    it "stores metadata as frozen hash" do
+      t = described_class.new(role: :user, content: "hi", metadata: { key: "value" })
+      expect(t.metadata).to eq({ key: "value" })
+      expect(t.metadata).to be_frozen
+    end
+
+    it "raises ArgumentError for invalid role" do
+      expect { described_class.new(role: :invalid, content: "hi") }
+        .to raise_error(ArgumentError, /role must be one of/)
+    end
+
+    it "raises ArgumentError for non-String content" do
+      expect { described_class.new(role: :user, content: 42) }
+        .to raise_error(ArgumentError, /content must be a String/)
+    end
+
+    it "raises ArgumentError for non-Hash metadata" do
+      expect { described_class.new(role: :user, content: "hi", metadata: "bad") }
+        .to raise_error(ArgumentError, /metadata must be a Hash/)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash with role, content, timestamp, metadata" do
+      ts = Time.utc(2026, 1, 1)
+      t = described_class.new(role: :user, content: "hello", timestamp: ts)
+      h = t.to_h
+      expect(h[:role]).to eq(:user)
+      expect(h[:content]).to eq("hello")
+      expect(h[:timestamp]).to eq(ts.iso8601)
+      expect(h[:metadata]).to eq({})
+    end
+
+    it "serializes nil timestamp as nil" do
+      t = described_class.new(role: :user, content: "hi")
+      expect(t.to_h[:timestamp]).to be_nil
+    end
+  end
+
+  describe "role predicates" do
+    it "#user_turn? returns true for :user" do
+      expect(described_class.new(role: :user, content: "x").user_turn?).to be(true)
+    end
+
+    it "#assistant_turn? returns true for :assistant" do
+      expect(described_class.new(role: :assistant, content: "x").assistant_turn?).to be(true)
+    end
+
+    it "#system_turn? returns true for :system" do
+      expect(described_class.new(role: :system, content: "x").system_turn?).to be(true)
+    end
+
+    it "#tool_turn? returns true for :tool" do
+      expect(described_class.new(role: :tool, content: "x").tool_turn?).to be(true)
+    end
+
+    it "#user_turn? returns false for :assistant" do
+      expect(described_class.new(role: :assistant, content: "x").user_turn?).to be(false)
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/normalization/intent_detector_spec.rb
+++ b/spec/wild/telemetry/pipeline/normalization/intent_detector_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Normalization::IntentDetector do
+  subject(:detector) { described_class.new }
+
+  describe "#detect" do
+    context "with intent-bearing turns" do
+      it 'detects "I need to" phrase' do
+        turns = [make_turn(role: :user, content: "I need to fix this bug")]
+        intents = detector.detect(turns)
+        expect(intents).not_to be_empty
+      end
+
+      it 'detects "Let me" phrase' do
+        turns = [make_turn(role: :assistant, content: "Let me check the logs for you")]
+        intents = detector.detect(turns)
+        expect(intents).not_to be_empty
+      end
+
+      it "detects \"I can't find a tool for\" phrase" do
+        turns = [make_turn(role: :assistant, content: "I can't find a tool for executing tests")]
+        intents = detector.detect(turns)
+        expect(intents).not_to be_empty
+        expect(intents.first.confidence).to be >= 0.8
+      end
+
+      it "detects \"There's no way to\" phrase" do
+        turns = [make_turn(role: :assistant, content: "There's no way to run code directly")]
+        intents = detector.detect(turns)
+        expect(intents.first.confidence).to be >= 0.7
+      end
+
+      it 'detects "I will" phrase' do
+        turns = [make_turn(role: :assistant, content: "I will analyze the data now")]
+        intents = detector.detect(turns)
+        expect(intents).not_to be_empty
+      end
+
+      it "includes source_turn_index in intent" do
+        turns = [
+          make_turn(role: :user, content: "hello"),
+          make_turn(role: :assistant, content: "I need to find that file")
+        ]
+        intents = detector.detect(turns)
+        expect(intents.first.source_turn_index).to eq(1)
+      end
+    end
+
+    context "with tool-call content" do
+      it "skips tool-use content turns" do
+        turns = [make_turn(role: :assistant, content: "[tool_use] inspect_routes({})")]
+        intents = detector.detect(turns)
+        expect(intents).to be_empty
+      end
+
+      it "skips mcp:request content" do
+        turns = [make_turn(role: :user, content: "[mcp:request] tools/call foo({})")]
+        intents = detector.detect(turns)
+        expect(intents).to be_empty
+      end
+    end
+
+    context "with tool role turns" do
+      it "skips tool role turns" do
+        turns = [make_turn(role: :tool, content: "I need to show you the results")]
+        intents = detector.detect(turns)
+        expect(intents).to be_empty
+      end
+    end
+
+    context "with threshold filtering" do
+      it "filters out intents below threshold" do
+        Wild.configure { |c| c.telemetry.pipeline.intent_confidence_threshold = 0.99 }
+        turns = [make_turn(role: :user, content: "I need to do something")]
+        intents = detector.detect(turns, config: Wild.config.telemetry.pipeline)
+        expect(intents).to be_empty
+      end
+
+      it "includes intents at or above threshold" do
+        Wild.configure { |c| c.telemetry.pipeline.intent_confidence_threshold = 0.0 }
+        turns = [make_turn(role: :user, content: "I need to do something")]
+        intents = detector.detect(turns, config: Wild.config.telemetry.pipeline)
+        expect(intents).not_to be_empty
+      end
+    end
+
+    context "with empty or plain turns" do
+      it "returns empty array for empty turns array" do
+        expect(detector.detect([])).to eq([])
+      end
+
+      it "skips empty content turns" do
+        turns = [make_turn(role: :user, content: "")]
+        expect(detector.detect(turns)).to eq([])
+      end
+
+      it "does not detect intent in plain sentences without markers" do
+        turns = [make_turn(role: :user, content: "The weather is nice today")]
+        expect(detector.detect(turns)).to be_empty
+      end
+    end
+
+    it "raises NormalizationError for non-Array input" do
+      expect { detector.detect("bad") }
+        .to raise_error(Wild::Telemetry::Pipeline::NormalizationError)
+    end
+
+    it "returns Intent objects" do
+      turns = [make_turn(role: :user, content: "I need to debug this")]
+      intents = detector.detect(turns)
+      expect(intents).to all(be_a(Wild::Telemetry::Pipeline::Models::Intent))
+    end
+
+    it "returns at most one intent per turn" do
+      turns = [make_turn(role: :assistant, content: "I need to check. Let me try. I will do it.")]
+      intents = detector.detect(turns)
+      turn_indices = intents.map(&:source_turn_index)
+      expect(turn_indices.uniq.size).to eq(turn_indices.size)
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/normalization/tool_extractor_spec.rb
+++ b/spec/wild/telemetry/pipeline/normalization/tool_extractor_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Normalization::ToolExtractor do
+  subject(:extractor) { described_class.new }
+
+  describe "#extract" do
+    context "with tool_use blocks" do
+      it "extracts tool name from [tool_use] content" do
+        turns = [make_turn(role: :assistant, content: "[tool_use] inspect_routes({})")]
+        refs = extractor.extract(turns)
+        expect(refs.map(&:name)).to include("inspect_routes")
+      end
+
+      it "sets action to :called for tool_use" do
+        turns = [make_turn(role: :assistant, content: "[tool_use] inspect_routes({})")]
+        refs = extractor.extract(turns)
+        expect(refs.first.action).to eq(:called)
+      end
+    end
+
+    context "with tool_result blocks" do
+      it "extracts tool name from [tool_result:name] content" do
+        turns = [make_turn(role: :tool, content: "[tool_result:inspect_routes] Found 42 routes")]
+        refs = extractor.extract(turns)
+        expect(refs.map(&:name)).to include("inspect_routes")
+      end
+
+      it "sets outcome to :success for tool_result" do
+        turns = [make_turn(role: :tool, content: "[tool_result:inspect_routes] found it")]
+        refs = extractor.extract(turns)
+        ref = refs.find { |r| r.name == "inspect_routes" }
+        expect(ref.outcome).to eq(:success)
+      end
+    end
+
+    context "with mcp:// references" do
+      it "extracts tool name from mcp:// URI" do
+        turns = [make_turn(role: :assistant, content: "Use mcp://list_resources to get data")]
+        refs = extractor.extract(turns)
+        expect(refs.map(&:name)).to include("list_resources")
+      end
+
+      it "sets action to :mentioned for mcp:// refs" do
+        turns = [make_turn(role: :assistant, content: "Try mcp://inspect_routes")]
+        refs = extractor.extract(turns)
+        ref = refs.find { |r| r.name == "inspect_routes" }
+        expect(ref.action).to eq(:mentioned)
+      end
+    end
+
+    context "with mcp:request content" do
+      it "extracts tool name from mcp request" do
+        turns = [make_turn(role: :user, content: "[mcp:request] tools/call inspect_routes({})")]
+        refs = extractor.extract(turns)
+        expect(refs.map(&:name)).to include("inspect_routes")
+      end
+    end
+
+    context "with mcp:result content" do
+      it "creates a :called/:success reference" do
+        turns = [make_turn(role: :tool,
+                           content: "[mcp:result] Found routes",
+                           metadata: { tool_name: "inspect_routes" })]
+        refs = extractor.extract(turns)
+        ref = refs.find { |r| r.name == "inspect_routes" }
+        expect(ref).not_to be_nil
+        expect(ref.outcome).to eq(:success)
+      end
+    end
+
+    context "with mcp:error content" do
+      it "creates a :failed/:error reference" do
+        turns = [make_turn(role: :tool,
+                           content: '[mcp:error] {"code": -1}',
+                           metadata: { tool_name: "bad_tool" })]
+        refs = extractor.extract(turns)
+        ref = refs.find { |r| r.name == "bad_tool" }
+        expect(ref).not_to be_nil
+        expect(ref.action).to eq(:failed)
+        expect(ref.outcome).to eq(:error)
+      end
+    end
+
+    context "with missing-tool patterns" do
+      it "detects \"I can't find a tool for\" as :not_found" do
+        turns = [make_turn(role: :assistant, content: "I can't find a tool for running tests")]
+        refs = extractor.extract(turns)
+        expect(refs.map(&:action)).to include(:not_found)
+      end
+
+      it "sets outcome to :not_available for not_found" do
+        turns = [make_turn(role: :assistant, content: "I don't have a tool for this")]
+        refs = extractor.extract(turns)
+        ref = refs.find { |r| r.action == :not_found }
+        expect(ref.outcome).to eq(:not_available)
+      end
+    end
+
+    context "with turns array" do
+      it "sets correct turn_index for each reference" do
+        turns = turns_with_tool_calls
+        refs = extractor.extract(turns)
+        expect(refs.map(&:turn_index)).to all(be_a(Integer))
+      end
+
+      it "deduplicates same name/action/index combinations" do
+        content = "[tool_use] inspect_routes({}) and also [tool_use] inspect_routes({})"
+        turns = [make_turn(role: :assistant, content: content)]
+        refs = extractor.extract(turns)
+        keys = refs.map { |r| [r.name, r.action, r.turn_index] }
+        expect(keys.uniq).to eq(keys)
+      end
+    end
+
+    it "returns empty array for turns with no tool content" do
+      turns = [make_turn(role: :user, content: "Hello, how are you?")]
+      expect(extractor.extract(turns)).to be_empty
+    end
+
+    it "raises NormalizationError for non-Array input" do
+      expect { extractor.extract("bad") }
+        .to raise_error(Wild::Telemetry::Pipeline::NormalizationError)
+    end
+
+    it "returns ToolReference objects" do
+      turns = turns_with_tool_calls
+      refs = extractor.extract(turns)
+      expect(refs).to all(be_a(Wild::Telemetry::Pipeline::Models::ToolReference))
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/normalization/turn_normalizer_spec.rb
+++ b/spec/wild/telemetry/pipeline/normalization/turn_normalizer_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Normalization::TurnNormalizer do
+  subject(:normalizer) { described_class.new }
+
+  describe "#normalize" do
+    context "with content within length limit" do
+      it "returns unchanged content" do
+        turns = [make_turn(content: "short content")]
+        result = normalizer.normalize(turns)
+        expect(result.first.content).to eq("short content")
+      end
+    end
+
+    context "with content exceeding max_turn_content_length" do
+      it "truncates content to configured max" do
+        long = "x" * 20_000
+        turns = [make_turn(content: long)]
+
+        Wild.configure { |c| c.telemetry.pipeline.max_turn_content_length = 100 }
+        result = normalizer.normalize(turns, config: Wild.config.telemetry.pipeline)
+        expect(result.first.content.length).to eq(100)
+      end
+    end
+
+    context "with too many turns" do
+      it "truncates to max_turns_per_transcript" do
+        turns = 50.times.map { |i| make_turn(content: "turn #{i}") }
+        Wild.configure { |c| c.telemetry.pipeline.max_turns_per_transcript = 10 }
+        result = normalizer.normalize(turns, config: Wild.config.telemetry.pipeline)
+        expect(result.size).to eq(10)
+      end
+
+      it "keeps the first N turns" do
+        turns = 5.times.map { |i| make_turn(content: "turn #{i}") }
+        Wild.configure { |c| c.telemetry.pipeline.max_turns_per_transcript = 3 }
+        result = normalizer.normalize(turns, config: Wild.config.telemetry.pipeline)
+        expect(result.map(&:content)).to eq(["turn 0", "turn 1", "turn 2"])
+      end
+    end
+
+    context "with turns within limit" do
+      it "returns all turns when under max" do
+        turns = 5.times.map { |i| make_turn(content: "turn #{i}") }
+        result = normalizer.normalize(turns)
+        expect(result.size).to eq(5)
+      end
+    end
+
+    it "preserves role, timestamp, and metadata through normalization" do
+      ts = Time.utc(2026, 1, 1)
+      turn = make_turn(role: :assistant, content: "hi", timestamp: ts, metadata: { key: "val" })
+      result = normalizer.normalize([turn])
+      expect(result.first.role).to eq(:assistant)
+      expect(result.first.timestamp).to eq(ts)
+      expect(result.first.metadata).to eq({ key: "val" })
+    end
+
+    it "raises NormalizationError for non-Array input" do
+      expect { normalizer.normalize("bad") }
+        .to raise_error(Wild::Telemetry::Pipeline::NormalizationError)
+    end
+
+    it "returns empty array for empty input" do
+      expect(normalizer.normalize([])).to eq([])
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/privacy/content_filter_spec.rb
+++ b/spec/wild/telemetry/pipeline/privacy/content_filter_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Privacy::ContentFilter do
+  subject(:filter) { described_class.new }
+
+  describe "#sensitive?" do
+    it "detects email addresses" do
+      expect(filter.sensitive?("My email is user@example.com")).to be(true)
+    end
+
+    it "detects IP addresses" do
+      expect(filter.sensitive?("Server at 192.168.1.100")).to be(true)
+    end
+
+    it "detects API key patterns" do
+      expect(filter.sensitive?("api_key=sk-abc123def456ghi789jkl")).to be(true)
+    end
+
+    it "detects AWS access keys" do
+      expect(filter.sensitive?("Key: AKIAIOSFODNN7EXAMPLE")).to be(true)
+    end
+
+    it "detects GitHub tokens" do
+      token = "ghp_#{"a" * 36}"
+      expect(filter.sensitive?("token=#{token}")).to be(true)
+    end
+
+    it "detects absolute paths when strip_absolute_paths is true" do
+      expect(filter.sensitive?("File at /home/user/secrets/key.pem")).to be(true)
+    end
+
+    it "does not detect absolute paths when strip_absolute_paths is false" do
+      Wild.configure { |c| c.telemetry.pipeline.strip_absolute_paths = false }
+      expect(filter.sensitive?("Path: /usr/bin/ruby", config: Wild.config.telemetry.pipeline))
+        .to be(false)
+    end
+
+    it "detects code blocks as file contents when strip_file_contents is true" do
+      content = "Here:\n```ruby\nsecret = 'foo'\n```"
+      expect(filter.sensitive?(content)).to be(true)
+    end
+
+    it "does not flag code blocks when strip_file_contents is false" do
+      Wild.configure { |c| c.telemetry.pipeline.strip_file_contents = false }
+      content = "Here:\n```ruby\nx = 1\n```"
+      expect(filter.sensitive?(content, config: Wild.config.telemetry.pipeline)).to be(false)
+    end
+
+    it "returns false for clean content" do
+      expect(filter.sensitive?("The test passed successfully")).to be(false)
+    end
+
+    it "returns false for empty string" do
+      expect(filter.sensitive?("")).to be(false)
+    end
+
+    it "detects custom patterns" do
+      Wild.configure { |c| c.telemetry.pipeline.custom_patterns = [/SECRET_WORD/] }
+      expect(filter.sensitive?("password is SECRET_WORD here", config: Wild.config.telemetry.pipeline))
+        .to be(true)
+    end
+
+    it "does not detect custom patterns when not configured" do
+      expect(filter.sensitive?("password is SECRET_WORD here")).to be(false)
+    end
+  end
+
+  describe "#patterns_matching" do
+    it "returns matching patterns" do
+      patterns = filter.patterns_matching("email: user@example.com")
+      expect(patterns).not_to be_empty
+    end
+
+    it "returns empty array for clean content" do
+      patterns = filter.patterns_matching("clean content here")
+      expect(patterns).to eq([])
+    end
+
+    it "returns multiple patterns for multiple hits" do
+      content = "user@example.com connected from 10.0.0.1"
+      patterns = filter.patterns_matching(content)
+      expect(patterns.size).to be >= 2
+    end
+  end
+end

--- a/spec/wild/telemetry/pipeline/privacy/redactor_spec.rb
+++ b/spec/wild/telemetry/pipeline/privacy/redactor_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Pipeline::Privacy::Redactor do
+  subject(:redactor) { described_class.new }
+
+  describe "#redact_content" do
+    it "redacts email addresses" do
+      result = redactor.redact_content("Contact user@example.com today")
+      expect(result).not_to include("user@example.com")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it "redacts IP addresses" do
+      result = redactor.redact_content("Server is at 192.168.0.1")
+      expect(result).to include("[REDACTED]")
+    end
+
+    it "redacts AWS access keys" do
+      result = redactor.redact_content("Key is AKIAIOSFODNN7EXAMPLE")
+      expect(result).not_to include("AKIAIOSFODNN7EXAMPLE")
+    end
+
+    it "redacts GitHub tokens" do
+      token = "ghp_#{"a" * 36}"
+      result = redactor.redact_content("token=#{token}")
+      expect(result).not_to include(token)
+    end
+
+    it "redacts absolute paths when strip_absolute_paths is true" do
+      result = redactor.redact_content("File at /home/user/secrets.yml")
+      expect(result).not_to include("/home/user/secrets.yml")
+    end
+
+    it "preserves absolute paths when strip_absolute_paths is false" do
+      Wild.configure { |c| c.telemetry.pipeline.strip_absolute_paths = false }
+      result = redactor.redact_content("/usr/bin/ruby", config: Wild.config.telemetry.pipeline)
+      expect(result).to include("/usr/bin/ruby")
+    end
+
+    it "redacts code blocks when strip_file_contents is true" do
+      content = "Check this:\n```python\nsecret='abc'\n```"
+      result = redactor.redact_content(content)
+      expect(result).not_to include("secret='abc'")
+    end
+
+    it "preserves code blocks when strip_file_contents is false" do
+      Wild.configure { |c| c.telemetry.pipeline.strip_file_contents = false }
+      content = "Check:\n```python\nx=1\n```"
+      result = redactor.redact_content(content, config: Wild.config.telemetry.pipeline)
+      expect(result).to include("x=1")
+    end
+
+    it "uses custom redaction marker" do
+      Wild.configure { |c| c.telemetry.pipeline.redaction_marker = "***" }
+      result = redactor.redact_content("email: test@test.com", config: Wild.config.telemetry.pipeline)
+      expect(result).to include("***")
+    end
+
+    it "applies custom patterns" do
+      Wild.configure { |c| c.telemetry.pipeline.custom_patterns = [/MY_SECRET_KEY/] }
+      result = redactor.redact_content("password=MY_SECRET_KEY", config: Wild.config.telemetry.pipeline)
+      expect(result).not_to include("MY_SECRET_KEY")
+    end
+
+    it "returns empty string for empty input" do
+      expect(redactor.redact_content("")).to eq("")
+    end
+
+    it "returns clean content unchanged" do
+      clean = "The test suite ran and passed in 2.3 seconds"
+      expect(redactor.redact_content(clean)).to eq(clean)
+    end
+  end
+
+  describe "#redact_turn" do
+    it "returns a new Turn with redacted content" do
+      turn = make_turn(content: "email: user@example.com")
+      result = redactor.redact_turn(turn)
+      expect(result).to be_a(Wild::Telemetry::Pipeline::Models::Turn)
+      expect(result.content).to include("[REDACTED]")
+    end
+
+    it "preserves role, timestamp, and metadata" do
+      ts = Time.utc(2026, 1, 1)
+      turn = make_turn(role: :assistant, content: "hello", timestamp: ts, metadata: { k: "v" })
+      result = redactor.redact_turn(turn)
+      expect(result.role).to eq(:assistant)
+      expect(result.timestamp).to eq(ts)
+      expect(result.metadata).to eq({ k: "v" })
+    end
+
+    it "raises PrivacyError for non-Turn input" do
+      expect { redactor.redact_turn("not a turn") }
+        .to raise_error(Wild::Telemetry::Pipeline::PrivacyError)
+    end
+  end
+
+  describe "#redact_transcript" do
+    it "returns a new Transcript with all turns redacted" do
+      t = make_transcript(turns: turns_with_sensitive_content)
+      result = redactor.redact_transcript(t)
+      expect(result).to be_a(Wild::Telemetry::Pipeline::Models::Transcript)
+      result.turns.each do |turn|
+        expect(turn.content).not_to include("user@example.com")
+      end
+    end
+
+    it "adds redacted: true to metadata" do
+      t = make_transcript
+      result = redactor.redact_transcript(t)
+      expect(result.metadata[:redacted]).to be(true)
+    end
+
+    it "preserves source_type, source_id, and created_at" do
+      t = make_transcript(source_type: :claude_code, source_id: "session-1")
+      result = redactor.redact_transcript(t)
+      expect(result.source_type).to eq(:claude_code)
+      expect(result.source_id).to eq("session-1")
+      expect(result.created_at).to eq(t.created_at)
+    end
+
+    it "raises PrivacyError for non-Transcript input" do
+      expect { redactor.redact_transcript("bad") }
+        .to raise_error(Wild::Telemetry::Pipeline::PrivacyError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Role 5 PR-9 — moves `wild-transcript-pipeline` into `Wild::Telemetry::Pipeline`. **Second of three** for the `wild-rvv.5` Telemetry epic (Collector #27; Analysis next). Tier 1 per ADR-0003.

## What landed

| Layer | Change |
|---|---|
| `lib/wild/telemetry/pipeline/` | 16 source files (ingestion, normalization, privacy, models, export) |
| `lib/wild/telemetry/pipeline.rb` | Loader + `.process` convenience method |
| `spec/wild/telemetry/pipeline/` | 19 specs; `TranscriptFixtures` rewrapped; `.process` + flat config rewritten |
| `Wild::Configuration::Telemetry::Pipeline` | Extended 1 → 8 settings (defaults verbatim) |
| `Wild::Telemetry::Pipeline::Error` | `IngestionError`, `NormalizationError`, `PrivacyError`, `ExportError` |
| `version.rb` + `configuration.rb` (F1) | Deleted; `json_exporter` version → `Wild::VERSION` |

## What is intentionally NOT in this PR

All `wild-rvv.5` children: F7 (`5.1`), F8 (`5.2`), MIN-Kleppmann (`5.3`), F6 export audit (`5.4`). Config validation + freeze machinery dropped (no-freeze design).

## Local verification

| Gate | Result |
|---|---|
| `bundle exec rspec` | **1840 examples, 0 failures** (1549 prior + 291 new) |
| `bundle exec rubocop` | 298 files, **0 offenses** |
| `ruby -Ilib` smoke-load | `Wild::Telemetry::Pipeline::*` resolves; `.process` present; `redaction_marker` → `[REDACTED]` |

CodeQL note: this gem's markdown exporter builds output without table-cell escaping (no `escape_md`/`gsub`), so it's clean of the finding class that hit #25/#26.

## Bead linkage

- **`wild-rvv.5`** (epic, in_progress) — Collector ✓ + Pipeline ✓; only Analysis (gap-miner) remains in PR-10 to complete the epic structure (and all of Tier 2).

## Test plan

- [ ] CI green on Ruby 3.2 / 3.3 / 3.4
- [ ] CodeQL clean
- [ ] Codecov Telemetry delta ≥ 80%
- [ ] No new Packwerk boundary violations (Tier 1)

- Jeremy Longshore
intentsolutions.io