### PR TITLE
feat(telemetry): move wild-gap-miner into Wild::Telemetry::Analysis (Role 5 PR-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,40 @@ section splits into a separate file.
 
 ### Wild::Telemetry::Analysis
 
-- _(pending: P1 code move from `wild-gap-miner`)_
+- Moved 25 source files from `wild-gap-miner/lib/wild_gap_miner/` into
+  `lib/wild/telemetry/analysis/` under the 3-deep
+  `Wild::Telemetry::Analysis::*` namespace (Role 5 PR-10; **completes the
+  three-gem `wild-rvv.5` Telemetry epic structure**). Sub-directories
+  preserved: `models/`, `ingestion/`, `analyzers/`, `scoring/`,
+  `recommendations/`, `report/`, `export/`. Module Zeitwerk-rewritten from
+  compact form. New loader at `lib/wild/telemetry/analysis.rb` carries the
+  `Wild::Telemetry::Analysis.analyze` convenience method (parse export →
+  build gap report) from the old gem entry point.
+- 25 specs (unit + adversarial + integration) moved to
+  `spec/wild/telemetry/analysis/`. `TelemetryFixtures` rewrapped as
+  `Wild::Telemetry::Analysis::TestSupport::TelemetryFixtures`; `HEADER_DATA`
+  constant refs + flat config setters rewritten to the nested API.
+- **F1 — `Wild::Configuration::Telemetry::Analysis` extended** from 1 setting
+  (`gap_threshold` from PR-B) to 9: the 8 old-gem thresholds (`denial_threshold`
+  0.2, `failure_threshold` 0.15, `latency_p95_threshold_ms` 500.0,
+  `utilization_min_count` 5, `coverage_min_fraction` 0.3,
+  `pattern_min_occurrences` 3, `max_gaps_per_type` 50, `severity_weights`
+  all-1.0 six-signal map) plus `gap_threshold`. Defaults verbatim from the
+  gem's DEFAULTS hash. Deleted `version.rb` + `configuration.rb`; orphaned
+  `configuration_spec.rb` removed.
+- **MIN-Armstrong — `Wild::Telemetry::Analysis::Error` subtree added**:
+  `ParseError`, `ValidationError`, `SchemaError`, `ExportError`. Old gem's
+  `ConfigurationError` subsumed by `Wild::ConfigurationError`.
+- **Fixture isolation fix** — all per-namespace fixture modules are now
+  `config.include`d scoped by `file_path` (not globally). `build_event`
+  collided between `Wild::Hooks::TestSupport::HookFixtures` and the telemetry
+  `TelemetryFixtures`; global includes let the last-loaded shadow the rest.
+  Path-scoping binds each namespace's helpers to its own specs.
+- Pre-existing complexity (`coverage_analyzer` AbcSize, `Gap` ParameterLists)
+  handled with localized inline disables — no refactor.
+- **NOT in this PR** (deferred, `wild-rvv.5` children): F7 (`5.1`), F8 (`5.2`),
+  MIN-Kleppmann (`5.3`), F6 export audit (`5.4`). Config validation + freeze
+  machinery dropped; 8 validation/freeze adversarial specs deleted per F3.
 
 ### Wild::Hooks
 

--- a/lib/wild.rb
+++ b/lib/wild.rb
@@ -11,6 +11,7 @@ require "wild/analyzers/permission"
 require "wild/analyzers/test_flakes"
 require "wild/telemetry/collector"
 require "wild/telemetry/pipeline"
+require "wild/telemetry/analysis"
 
 # wild — Rails engine + generator: ten Wild::* namespaces consolidated into one
 # mountable gem. Council-blessed Topology A. See 000-docs/adr/ADR-0001-topology.md

--- a/lib/wild/configuration.rb
+++ b/lib/wild/configuration.rb
@@ -151,9 +151,40 @@ module Wild
         end
       end
 
-      Analysis = Struct.new(:gap_threshold, keyword_init: true) do
+      ANALYSIS_DEFAULT_SEVERITY_WEIGHTS = {
+        denial: 1.0, failure: 1.0, latency: 1.0,
+        utilization: 1.0, coverage: 1.0, pattern: 1.0
+      }.freeze
+
+      # Analysis carries the gap-miner thresholds the old gem exposed plus the
+      # PR-B `gap_threshold` flag (placeholder — not read by the moved code;
+      # kept for back-compat). Defaults preserved verbatim from the gem's
+      # DEFAULTS hash; per-setter validation + freeze! machinery NOT carried
+      # over (no-freeze design).
+      Analysis = Struct.new(
+        :gap_threshold,
+        :denial_threshold,
+        :failure_threshold,
+        :latency_p95_threshold_ms,
+        :utilization_min_count,
+        :coverage_min_fraction,
+        :pattern_min_occurrences,
+        :max_gaps_per_type,
+        :severity_weights,
+        keyword_init: true
+      ) do
         def initialize(**kwargs)
-          super(gap_threshold: kwargs.fetch(:gap_threshold, 0.7))
+          super(
+            gap_threshold: kwargs.fetch(:gap_threshold, 0.7),
+            denial_threshold: kwargs.fetch(:denial_threshold, 0.2),
+            failure_threshold: kwargs.fetch(:failure_threshold, 0.15),
+            latency_p95_threshold_ms: kwargs.fetch(:latency_p95_threshold_ms, 500.0),
+            utilization_min_count: kwargs.fetch(:utilization_min_count, 5),
+            coverage_min_fraction: kwargs.fetch(:coverage_min_fraction, 0.3),
+            pattern_min_occurrences: kwargs.fetch(:pattern_min_occurrences, 3),
+            max_gaps_per_type: kwargs.fetch(:max_gaps_per_type, 50),
+            severity_weights: kwargs.fetch(:severity_weights, ANALYSIS_DEFAULT_SEVERITY_WEIGHTS.dup)
+          )
         end
       end
 

--- a/lib/wild/error.rb
+++ b/lib/wild/error.rb
@@ -109,6 +109,23 @@ module Wild
       # Raised when transcript export fails.
       class ExportError < Error; end
     end
+
+    # Analysis sub-namespace errors (from wild-gap-miner).
+    module Analysis
+      class Error < Wild::Telemetry::Error; end
+
+      # Raised when a telemetry export file cannot be parsed.
+      class ParseError < Error; end
+
+      # Raised when a record fails validation.
+      class ValidationError < Error; end
+
+      # Raised when an export record does not conform to its schema.
+      class SchemaError < Error; end
+
+      # Raised when gap-report export fails.
+      class ExportError < Error; end
+    end
   end
 
   module Hooks

--- a/lib/wild/telemetry/analysis.rb
+++ b/lib/wild/telemetry/analysis.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Wild::Telemetry::Analysis — Tier 2 per ADR-0003. Gap analysis over telemetry
+# exports: ingests a JSONL export, runs denial/failure/latency/utilization/
+# coverage/pattern analyzers, scores severity, ranks priority, and builds a
+# gap report with recommendations.
+#
+# Reads its policy from Wild.config.telemetry.analysis. Code moved from the
+# old wild-gap-miner gem in Role 5 PR-10 (third + final Telemetry sub-namespace
+# move — completes the wild-rvv.5 epic structure).
+#
+# Deferred behavior changes tracked under wild-rvv.5's children (F7/F8/
+# MIN-Kleppmann/F6).
+
+# Models
+require "wild/telemetry/analysis/models/telemetry_record"
+require "wild/telemetry/analysis/models/export_header"
+require "wild/telemetry/analysis/models/event_record"
+require "wild/telemetry/analysis/models/session_summary"
+require "wild/telemetry/analysis/models/tool_utilization"
+require "wild/telemetry/analysis/models/outcome_distribution"
+require "wild/telemetry/analysis/models/latency_stats"
+require "wild/telemetry/analysis/models/pattern_record"
+require "wild/telemetry/analysis/models/gap"
+require "wild/telemetry/analysis/models/gap_report"
+
+# Ingestion
+require "wild/telemetry/analysis/ingestion/record_factory"
+require "wild/telemetry/analysis/ingestion/export_parser"
+
+# Analyzers
+require "wild/telemetry/analysis/analyzers/base"
+require "wild/telemetry/analysis/analyzers/denial_analyzer"
+require "wild/telemetry/analysis/analyzers/failure_analyzer"
+require "wild/telemetry/analysis/analyzers/latency_analyzer"
+require "wild/telemetry/analysis/analyzers/utilization_analyzer"
+require "wild/telemetry/analysis/analyzers/coverage_analyzer"
+require "wild/telemetry/analysis/analyzers/pattern_analyzer"
+
+# Scoring
+require "wild/telemetry/analysis/scoring/severity_scorer"
+require "wild/telemetry/analysis/scoring/priority_ranker"
+
+# Recommendations + report
+require "wild/telemetry/analysis/recommendations/engine"
+require "wild/telemetry/analysis/report/builder"
+
+# Export — flagged for F6 wire-or-delete audit under wild-rvv.5.4.
+require "wild/telemetry/analysis/export/json_exporter"
+require "wild/telemetry/analysis/export/markdown_exporter"
+
+module Wild
+  module Telemetry
+    module Analysis
+      # Convenience: parse a telemetry-export JSONL file and build a gap report.
+      def self.analyze(path, config: Wild.config.telemetry.analysis)
+        parser = Ingestion::ExportParser.new(config: config)
+        parsed = parser.parse_file(path)
+        builder_records = parsed[:records].merge(header: parsed[:header])
+        Report::Builder.new(records: builder_records, config: config).build
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/analyzers/base.rb
+++ b/lib/wild/telemetry/analysis/analyzers/base.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Analyzers
+        class Base
+          attr_reader :config
+
+          def initialize(config: Wild.config.telemetry.analysis)
+            @config = config
+          end
+
+          # Subclasses implement this. records is a Hash<Symbol, Array<TelemetryRecord>>.
+          # Returns Array<Models::Gap>.
+          def analyze(_records)
+            raise NotImplementedError, "#{self.class} must implement #analyze"
+          end
+
+          protected
+
+          def gap_type
+            raise NotImplementedError, "#{self.class} must implement #gap_type"
+          end
+
+          def build_gap(action:, severity:, evidence:, description:, recommendation: nil)
+            Models::Gap.new(
+              type: gap_type,
+              action: action,
+              severity: severity,
+              evidence: evidence,
+              description: description,
+              recommendation: recommendation
+            )
+          end
+
+          def clamp_severity(value)
+            value.clamp(0.0, 1.0)
+          end
+
+          def limit_gaps(gaps)
+            gaps.sort.first(config.max_gaps_per_type)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/analyzers/coverage_analyzer.rb
+++ b/lib/wild/telemetry/analysis/analyzers/coverage_analyzer.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Analyzers
+        # Identifies callers that use a suspiciously narrow fraction of available actions.
+        class CoverageAnalyzer < Base
+          def analyze(records)
+            session_summaries = Array(records[:session_summary])
+            utilizations = Array(records[:tool_utilization])
+            return [] if session_summaries.empty? || utilizations.empty?
+
+            all_actions = utilizations.map(&:action).uniq
+            return [] if all_actions.empty?
+
+            gaps = session_summaries.filter_map { |s| coverage_gap_for(s, all_actions) }
+            limit_gaps(gaps)
+          end
+
+          protected
+
+          def gap_type
+            :coverage
+          end
+
+          private
+
+          # rubocop:disable Metrics/AbcSize
+          def coverage_gap_for(session, all_actions)
+            covered = session.distinct_actions & all_actions
+            fraction = covered.size.to_f / all_actions.size
+            return nil if fraction >= config.coverage_min_fraction
+
+            build_gap(
+              action: session.caller_id,
+              severity: clamp_severity(1.0 - fraction),
+              evidence: coverage_evidence(covered, all_actions, fraction),
+              description: coverage_description(session.caller_id, covered.size, all_actions.size, fraction),
+              recommendation: "Review whether caller #{session.caller_id} is missing capabilities. " \
+                              "Low coverage may indicate undiscovered tools."
+            )
+          end
+          # rubocop:enable Metrics/AbcSize
+
+          def coverage_evidence(covered, all_actions, fraction)
+            {
+              covered_actions: covered.size,
+              total_actions: all_actions.size,
+              coverage_fraction: fraction.round(4),
+              coverage_min_fraction: config.coverage_min_fraction
+            }
+          end
+
+          def coverage_description(caller_id, covered_count, total_count, fraction)
+            "Caller #{caller_id} used #{covered_count}/#{total_count} actions " \
+              "(#{(fraction * 100).round(1)}% coverage, " \
+              "minimum: #{(config.coverage_min_fraction * 100).round(1)}%)"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/analyzers/denial_analyzer.rb
+++ b/lib/wild/telemetry/analysis/analyzers/denial_analyzer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Analyzers
+        # Identifies tools/actions with high denial rates.
+        class DenialAnalyzer < Base
+          def analyze(records)
+            distributions = Array(records[:outcome_distribution])
+            return [] if distributions.empty?
+
+            gaps = distributions.filter_map { |dist| denial_gap_for(dist) }
+            limit_gaps(gaps)
+          end
+
+          protected
+
+          def gap_type
+            :denial
+          end
+
+          private
+
+          def denial_gap_for(dist)
+            denial_rate = dist.percentage_for("denied")
+            return nil if denial_rate < config.denial_threshold
+
+            build_gap(
+              action: dist.action,
+              severity: clamp_severity(denial_rate),
+              evidence: denial_evidence(dist, denial_rate),
+              description: denial_description(dist.action, denial_rate),
+              recommendation: denial_recommendation(dist.action)
+            )
+          end
+
+          def denial_evidence(dist, denial_rate)
+            {
+              denial_rate: denial_rate,
+              threshold: config.denial_threshold,
+              total_count: dist.total_count
+            }
+          end
+
+          def denial_description(action, denial_rate)
+            "#{action} has a denial rate of #{(denial_rate * 100).round(1)}% " \
+              "(threshold: #{(config.denial_threshold * 100).round(1)}%)"
+          end
+
+          def denial_recommendation(action)
+            "Review permission configuration for #{action}. " \
+              "High denial rates indicate callers lack required capabilities."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/analyzers/failure_analyzer.rb
+++ b/lib/wild/telemetry/analysis/analyzers/failure_analyzer.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Analyzers
+        # Identifies tools/actions with high error/failure rates.
+        class FailureAnalyzer < Base
+          def analyze(records)
+            utilizations = Array(records[:tool_utilization])
+            return [] if utilizations.empty?
+
+            gaps = utilizations.filter_map { |util| failure_gap_for(util) }
+            limit_gaps(gaps)
+          end
+
+          protected
+
+          def gap_type
+            :failure
+          end
+
+          private
+
+          def failure_gap_for(util)
+            failure_rate = 1.0 - util.success_rate.to_f
+            return nil if failure_rate < config.failure_threshold
+
+            build_gap(
+              action: util.action,
+              severity: clamp_severity(failure_rate),
+              evidence: failure_evidence(util, failure_rate),
+              description: failure_description(util.action, failure_rate, util.success_rate),
+              recommendation: failure_recommendation(util.action, util.invocation_count, failure_rate)
+            )
+          end
+
+          def failure_evidence(util, failure_rate)
+            {
+              failure_rate: failure_rate,
+              success_rate: util.success_rate,
+              threshold: config.failure_threshold,
+              invocation_count: util.invocation_count
+            }
+          end
+
+          def failure_description(action, failure_rate, success_rate)
+            "#{action} has a failure rate of #{(failure_rate * 100).round(1)}% " \
+              "(success rate: #{(success_rate * 100).round(1)}%)"
+          end
+
+          def failure_recommendation(action, invocation_count, failure_rate)
+            "Investigate error patterns for #{action}. " \
+              "#{invocation_count} invocations with #{(failure_rate * 100).round(1)}% failures."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/analyzers/latency_analyzer.rb
+++ b/lib/wild/telemetry/analysis/analyzers/latency_analyzer.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Analyzers
+        # Identifies tools/actions with high p95 latency.
+        class LatencyAnalyzer < Base
+          def analyze(records)
+            latency_records = Array(records[:latency_stats])
+            return [] if latency_records.empty?
+
+            gaps = latency_records.filter_map { |stat| latency_gap_for(stat) }
+            limit_gaps(gaps)
+          end
+
+          protected
+
+          def gap_type
+            :latency
+          end
+
+          private
+
+          def latency_gap_for(stat)
+            p95 = stat.p95.to_f
+            threshold = config.latency_p95_threshold_ms
+            return nil if p95 <= threshold
+
+            build_gap(
+              action: stat.action,
+              severity: latency_severity(p95, threshold),
+              evidence: latency_evidence(stat, p95, threshold),
+              description: "#{stat.action} p95 latency #{p95.round(1)}ms exceeds threshold of #{threshold.round(1)}ms",
+              recommendation: "Profile #{stat.action} for performance bottlenecks. " \
+                              "P95: #{p95.round(1)}ms, P99: #{stat.p99.round(1)}ms."
+            )
+          end
+
+          def latency_severity(p95, threshold)
+            # Severity scales with how much the threshold is exceeded (caps at 2x = 1.0)
+            ratio = [p95 / threshold, 2.0].min
+            clamp_severity(ratio - 1.0)
+          end
+
+          def latency_evidence(stat, p95, threshold)
+            {
+              p95_ms: p95,
+              p99_ms: stat.p99,
+              avg_ms: stat.avg,
+              threshold_ms: threshold
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/analyzers/pattern_analyzer.rb
+++ b/lib/wild/telemetry/analysis/analyzers/pattern_analyzer.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Analyzers
+        # Identifies recurring patterns (e.g., failure cascades) that indicate systemic gaps.
+        class PatternAnalyzer < Base
+          def analyze(records)
+            pattern_records = Array(records[:pattern])
+            return [] if pattern_records.empty?
+
+            gaps = pattern_records.filter_map { |p| pattern_gap_for(p) }
+            limit_gaps(gaps)
+          end
+
+          protected
+
+          def gap_type
+            :pattern
+          end
+
+          private
+
+          def pattern_gap_for(pattern)
+            return nil if pattern.occurrence_count < config.pattern_min_occurrences
+
+            action_label = pattern.sequence.join(" -> ")
+            build_gap(
+              action: action_label,
+              severity: compute_severity(pattern),
+              evidence: pattern_evidence(pattern),
+              description: pattern_description(pattern, action_label),
+              recommendation: recommendation_for(pattern)
+            )
+          end
+
+          def pattern_evidence(pattern)
+            {
+              pattern_type: pattern.pattern_type,
+              sequence: pattern.sequence,
+              occurrence_count: pattern.occurrence_count,
+              callers_affected: pattern.callers_affected,
+              min_occurrences: config.pattern_min_occurrences
+            }
+          end
+
+          def pattern_description(pattern, action_label)
+            "Pattern '#{pattern.pattern_type}' detected: #{action_label} " \
+              "(#{pattern.occurrence_count} occurrences, #{pattern.callers_affected} callers)"
+          end
+
+          def compute_severity(pattern)
+            # Failure cascades are considered higher severity
+            base = pattern.failure_cascade? ? 0.6 : 0.3
+            # Scale up with occurrence count (saturates at ~50 occurrences)
+            occurrence_factor = [pattern.occurrence_count / 50.0, 0.4].min
+            clamp_severity(base + occurrence_factor)
+          end
+
+          def recommendation_for(pattern)
+            if pattern.failure_cascade?
+              "Break the failure cascade in sequence: #{pattern.sequence.join(" -> ")}. " \
+                "Add retry logic or circuit breakers."
+            else
+              "Investigate the recurring pattern: #{pattern.sequence.join(" -> ")}. " \
+                "Appeared #{pattern.occurrence_count} times across #{pattern.callers_affected} callers."
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/analyzers/utilization_analyzer.rb
+++ b/lib/wild/telemetry/analysis/analyzers/utilization_analyzer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Analyzers
+        # Identifies tools/actions with very low utilization — potential waste or dead code.
+        class UtilizationAnalyzer < Base
+          def analyze(records)
+            utilizations = Array(records[:tool_utilization])
+            return [] if utilizations.empty?
+
+            gaps = utilizations.filter_map { |util| utilization_gap_for(util) }
+            limit_gaps(gaps)
+          end
+
+          protected
+
+          def gap_type
+            :utilization
+          end
+
+          private
+
+          def utilization_gap_for(util)
+            min_count = config.utilization_min_count
+            return nil if util.invocation_count >= min_count
+
+            ratio = util.invocation_count.to_f / min_count
+            build_gap(
+              action: util.action,
+              severity: clamp_severity(1.0 - ratio),
+              evidence: utilization_evidence(util, min_count),
+              description: utilization_description(util.action, util.invocation_count, min_count),
+              recommendation: utilization_recommendation(util.action)
+            )
+          end
+
+          def utilization_evidence(util, min_count)
+            {
+              invocation_count: util.invocation_count,
+              unique_callers: util.unique_callers,
+              min_count_threshold: min_count
+            }
+          end
+
+          def utilization_description(action, count, min_count)
+            "#{action} was invoked only #{count} time(s), below the minimum utilization threshold of #{min_count}"
+          end
+
+          def utilization_recommendation(action)
+            "Evaluate whether #{action} is discoverable and documented. " \
+              "Low utilization may indicate redundancy or poor discoverability."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/export/json_exporter.rb
+++ b/lib/wild/telemetry/analysis/export/json_exporter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Export
+        class JsonExporter
+          # Returns a JSON string for the given GapReport.
+          def export(report)
+            JSON.generate(report.to_h)
+          end
+
+          # Writes JSON to path and returns path.
+          def write(report, path)
+            content = export(report)
+            File.write(path, content)
+            path
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/export/markdown_exporter.rb
+++ b/lib/wild/telemetry/analysis/export/markdown_exporter.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Export
+        class MarkdownExporter
+          SEVERITY_LABELS = {
+            (0.7..1.0) => "HIGH",
+            (0.4...0.7) => "MEDIUM",
+            (0.0...0.4) => "LOW"
+          }.freeze
+
+          # Returns a Markdown string for the given GapReport.
+          def export(report)
+            lines = []
+            lines << "# Gap Analysis Report"
+            lines << ""
+            lines << "Generated: #{report.generated_at}"
+            lines << ""
+            lines << build_summary_section(report)
+            lines << ""
+            lines << build_gaps_section(report)
+            lines.join("\n")
+          end
+
+          # Writes Markdown to path and returns path.
+          def write(report, path)
+            content = export(report)
+            File.write(path, content)
+            path
+          end
+
+          private
+
+          def build_summary_section(report)
+            summary = report.summary
+            lines = ["## Summary", ""]
+            lines.concat(summary_stats_lines(summary))
+            lines << ""
+            lines.concat(by_type_lines(summary))
+            lines.concat(top_actions_lines(summary))
+            lines.join("\n")
+          end
+
+          def summary_stats_lines(summary)
+            [
+              "- **Total Gaps**: #{summary[:total_gaps]}",
+              "- **High Severity**: #{summary[:high_severity_count]}",
+              "- **Average Severity**: #{summary[:severity_avg]}"
+            ]
+          end
+
+          def by_type_lines(summary)
+            lines = ["### By Type", ""]
+            summary[:by_type].each { |type, count| lines << "- #{type}: #{count}" }
+            lines << ""
+            lines
+          end
+
+          def top_actions_lines(summary)
+            return [] if summary[:top_actions].empty?
+
+            lines = ["### Top Actions by Max Severity", ""]
+            summary[:top_actions].each do |entry|
+              lines << "- `#{entry[:action]}` — #{entry[:max_severity].round(3)}"
+            end
+            lines
+          end
+
+          def build_gaps_section(report)
+            return "## Gaps\n\n_No gaps detected._" if report.gaps.empty?
+
+            lines = ["## Gaps", ""]
+            report.gaps.each_with_index do |gap, idx|
+              lines << build_gap_entry(gap, idx + 1)
+              lines << ""
+            end
+            lines.join("\n")
+          end
+
+          def build_gap_entry(gap, number)
+            level = severity_level(gap.severity)
+            lines = ["### #{number}. [#{level}] #{gap.action} (#{gap.type})", ""]
+            lines << "**Severity**: #{gap.severity.round(3)}"
+            lines << ""
+            lines << gap.description
+            lines << ""
+            lines.concat(recommendation_lines(gap))
+            lines.concat(evidence_lines(gap))
+            lines.join("\n")
+          end
+
+          def recommendation_lines(gap)
+            return [] unless gap.recommendation
+
+            ["**Recommendation**: #{gap.recommendation}", ""]
+          end
+
+          def evidence_lines(gap)
+            lines = ["**Evidence**:", ""]
+            gap.evidence.each { |key, value| lines << "- `#{key}`: #{value}" }
+            lines
+          end
+
+          def severity_level(severity)
+            SEVERITY_LABELS.each do |range, label|
+              return label if range.cover?(severity)
+            end
+            "LOW"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/ingestion/export_parser.rb
+++ b/lib/wild/telemetry/analysis/ingestion/export_parser.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Ingestion
+        class ExportParser
+          attr_reader :config
+
+          def initialize(config: Wild.config.telemetry.analysis)
+            @config = config
+          end
+
+          # Parses a JSONL export file.
+          # Returns a hash:
+          #   { header: ExportHeader, records: Hash<Symbol, Array<TelemetryRecord>> }
+          def parse_file(path)
+            raise ParseError, "file not found: #{path}" unless File.exist?(path)
+
+            lines = File.readlines(path, chomp: true).reject(&:empty?)
+            raise ParseError, "export file is empty" if lines.empty?
+
+            parse_lines(lines)
+          end
+
+          # Parses a string of JSONL content (useful for testing).
+          def parse_string(content)
+            lines = content.split("\n").map(&:strip).reject(&:empty?)
+            raise ParseError, "export content is empty" if lines.empty?
+
+            parse_lines(lines)
+          end
+
+          private
+
+          def parse_lines(lines)
+            header_data = parse_json(lines.first, line_number: 1)
+            header = build_header(header_data)
+
+            records = build_records(lines.drop(1))
+
+            { header: header, records: records }
+          end
+
+          def parse_json(line, line_number:)
+            JSON.parse(line)
+          rescue JSON::ParserError => e
+            raise ParseError, "invalid JSON on line #{line_number}: #{e.message}"
+          end
+
+          def build_header(data)
+            header = Models::ExportHeader.new(data)
+            unless header.valid?
+              raise SchemaError, "export header missing required fields (export_type, schema_version, source_id)"
+            end
+
+            header
+          end
+
+          def build_records(lines)
+            records = Hash.new { |h, k| h[k] = [] }
+
+            lines.each_with_index do |line, index|
+              data = parse_json(line, line_number: index + 2)
+              record = RecordFactory.build(data)
+              records[record.record_type.to_sym] << record
+            end
+
+            records
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/ingestion/record_factory.rb
+++ b/lib/wild/telemetry/analysis/ingestion/record_factory.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Ingestion
+        class RecordFactory
+          RECORD_TYPE_MAP = {
+            "event" => Models::EventRecord,
+            "session_summary" => Models::SessionSummary,
+            "tool_utilization" => Models::ToolUtilization,
+            "outcome_distribution" => Models::OutcomeDistribution,
+            "latency_stats" => Models::LatencyStats,
+            "pattern" => Models::PatternRecord
+          }.freeze
+
+          def self.build(data)
+            record_type = data["record_type"]
+            klass = RECORD_TYPE_MAP[record_type]
+
+            if klass
+              klass.new(data)
+            else
+              Models::TelemetryRecord.new(data)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/event_record.rb
+++ b/lib/wild/telemetry/analysis/models/event_record.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class EventRecord < TelemetryRecord
+          attr_reader :event_type, :timestamp, :caller_id, :action, :outcome,
+                      :duration_ms, :metadata
+
+          VALID_OUTCOMES = %w[success denied error preview rate_limited].freeze
+
+          def initialize(data)
+            super
+            @event_type = data["event_type"]
+            @timestamp = data["timestamp"]
+            @caller_id = data["caller_id"]
+            @action = data["action"]
+            @outcome = data["outcome"]
+            @duration_ms = data["duration_ms"]
+            @metadata = data["metadata"] || {}
+          end
+
+          def success?
+            outcome == "success"
+          end
+
+          def denied?
+            outcome == "denied"
+          end
+
+          def error?
+            outcome == "error"
+          end
+
+          def rate_limited?
+            outcome == "rate_limited"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/export_header.rb
+++ b/lib/wild/telemetry/analysis/models/export_header.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class ExportHeader
+          attr_reader :export_type, :schema_version, :exported_at, :source_id,
+                      :time_range, :record_counts
+
+          def initialize(data)
+            @export_type = data["export_type"]
+            @schema_version = data["schema_version"]
+            @exported_at = data["exported_at"]
+            @source_id = data["source_id"]
+            @time_range = data["time_range"] || {}
+            @record_counts = data["record_counts"] || {}
+          end
+
+          def valid?
+            export_type == "session_telemetry" && !schema_version.nil? && !source_id.nil?
+          end
+
+          def to_h
+            {
+              export_type: export_type,
+              schema_version: schema_version,
+              exported_at: exported_at,
+              source_id: source_id,
+              time_range: time_range,
+              record_counts: record_counts
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/gap.rb
+++ b/lib/wild/telemetry/analysis/models/gap.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class Gap
+          VALID_TYPES = %i[denial failure latency utilization coverage pattern].freeze
+
+          attr_reader :type, :action, :severity, :evidence, :description, :recommendation
+
+          # rubocop:disable Metrics/ParameterLists
+          def initialize(type:, action:, severity:, evidence:, description:, recommendation: nil)
+            @type = type.to_sym
+            @action = action.to_s
+            @severity = severity.to_f
+            @evidence = evidence
+            @description = description.to_s
+            @recommendation = recommendation
+
+            validate!
+          end
+          # rubocop:enable Metrics/ParameterLists
+
+          def to_h
+            {
+              type: type,
+              action: action,
+              severity: severity,
+              evidence: evidence,
+              description: description,
+              recommendation: recommendation
+            }
+          end
+
+          def <=>(other)
+            other.severity <=> severity
+          end
+
+          include Comparable
+
+          private
+
+          def validate!
+            unless VALID_TYPES.include?(type)
+              raise ValidationError, "invalid gap type: #{type.inspect}. Must be one of #{VALID_TYPES.inspect}"
+            end
+
+            return if severity.between?(0.0, 1.0)
+
+            raise ValidationError, "severity must be between 0.0 and 1.0, got #{severity}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/gap_report.rb
+++ b/lib/wild/telemetry/analysis/models/gap_report.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class GapReport
+          attr_reader :header, :gaps, :generated_at
+
+          def initialize(header:, gaps:, generated_at: Time.now.utc.iso8601)
+            @header = header
+            @gaps = gaps.sort
+            @generated_at = generated_at
+          end
+
+          def summary
+            {
+              total_gaps: gaps.size,
+              by_type: gaps.group_by(&:type).transform_values(&:count),
+              severity_avg: severity_average,
+              high_severity_count: high_severity_count,
+              top_actions: top_actions
+            }
+          end
+
+          def gaps_of_type(type)
+            gaps.select { |g| g.type == type.to_sym }
+          end
+
+          def to_h
+            {
+              header: header&.to_h,
+              generated_at: generated_at,
+              summary: summary,
+              gaps: gaps.map(&:to_h)
+            }
+          end
+
+          private
+
+          def severity_average
+            return 0.0 if gaps.empty?
+
+            (gaps.sum(&:severity) / gaps.size).round(4)
+          end
+
+          def high_severity_count
+            gaps.count { |g| g.severity >= 0.7 }
+          end
+
+          def top_actions
+            gaps
+              .group_by(&:action)
+              .transform_values { |gs| gs.map(&:severity).max }
+              .sort_by { |_, max_sev| -max_sev }
+              .first(5)
+              .map { |action, max_sev| { action: action, max_severity: max_sev } }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/latency_stats.rb
+++ b/lib/wild/telemetry/analysis/models/latency_stats.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class LatencyStats < TelemetryRecord
+          attr_reader :action, :p50, :p95, :p99, :min, :max, :avg, :sample_count
+
+          def initialize(data)
+            super
+            @action = data["action"]
+            @p50 = ms_field(data, "p50")
+            @p95 = ms_field(data, "p95")
+            @p99 = ms_field(data, "p99")
+            @min = ms_field(data, "min")
+            @max = ms_field(data, "max")
+            @avg = ms_field(data, "avg")
+            @sample_count = data["sample_count"] || 0
+          end
+
+          private
+
+          # Accepts both `key_ms` (upstream contract) and bare `key` forms.
+          def ms_field(data, key)
+            data["#{key}_ms"] || data[key] || 0.0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/outcome_distribution.rb
+++ b/lib/wild/telemetry/analysis/models/outcome_distribution.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class OutcomeDistribution < TelemetryRecord
+          attr_reader :action, :distribution, :total_count
+
+          def initialize(data)
+            super
+            @action = data["action"]
+            # Support both 'distribution' and 'outcomes' keys per upstream contract
+            @distribution = data["distribution"] || data["outcomes"] || {}
+            @total_count = data["total_count"] || 0
+          end
+
+          def percentage_for(outcome)
+            distribution[outcome.to_s] || 0.0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/pattern_record.rb
+++ b/lib/wild/telemetry/analysis/models/pattern_record.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class PatternRecord < TelemetryRecord
+          attr_reader :pattern_type, :sequence, :occurrence_count, :callers_affected
+
+          def initialize(data)
+            super
+            @pattern_type = data["pattern_type"]
+            @sequence = Array(data["sequence"])
+            @occurrence_count = data["occurrence_count"] || 0
+            # Support both 'unique_callers' (upstream contract) and 'callers_affected'
+            @callers_affected = data["unique_callers"] || data["callers_affected"] || 0
+          end
+
+          def failure_cascade?
+            pattern_type == "failure_cascade"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/session_summary.rb
+++ b/lib/wild/telemetry/analysis/models/session_summary.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class SessionSummary < TelemetryRecord
+          attr_reader :caller_id, :event_count, :distinct_actions,
+                      :outcome_breakdown, :total_duration_ms
+
+          def initialize(data)
+            super
+            @caller_id = data["caller_id"]
+            @event_count = data["event_count"] || 0
+            @distinct_actions = Array(data["distinct_actions"])
+            @outcome_breakdown = data["outcome_breakdown"] || {}
+            @total_duration_ms = data["total_duration_ms"] || 0
+          end
+
+          def action_count
+            distinct_actions.length
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/telemetry_record.rb
+++ b/lib/wild/telemetry/analysis/models/telemetry_record.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class TelemetryRecord
+          attr_reader :record_type, :raw
+
+          def initialize(data)
+            @record_type = data["record_type"]
+            @raw = data
+          end
+
+          def to_h
+            raw.dup
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/models/tool_utilization.rb
+++ b/lib/wild/telemetry/analysis/models/tool_utilization.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Models
+        class ToolUtilization < TelemetryRecord
+          attr_reader :action, :invocation_count, :unique_callers,
+                      :success_rate, :avg_duration_ms
+
+          def initialize(data)
+            super
+            @action = data["action"]
+            @invocation_count = data["invocation_count"] || 0
+            @unique_callers = data["unique_callers"] || 0
+            @success_rate = data["success_rate"] || 0.0
+            @avg_duration_ms = data["avg_duration_ms"] || 0.0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/recommendations/engine.rb
+++ b/lib/wild/telemetry/analysis/recommendations/engine.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Recommendations
+        # Enriches gaps that lack recommendations with generated ones based on gap type.
+        class Engine
+          TEMPLATES = {
+            denial: "Review permission grants for %<action>s. " \
+                    "Denial rate %<rate>s indicates callers need additional capabilities.",
+            failure: "Investigate error handling for %<action>s. " \
+                     "High failure rate suggests fragile integration or missing error recovery.",
+            latency: "Profile and optimize %<action>s. " \
+                     "Latency exceeds acceptable thresholds and may impact user experience.",
+            utilization: "Evaluate whether %<action>s provides sufficient value given its low usage. " \
+                         "Consider deprecation or improved documentation.",
+            coverage: "Expand capability usage for %<action>s. " \
+                      "Low coverage may indicate discovery or documentation gaps.",
+            pattern: "Investigate and resolve the recurring pattern involving %<action>s. " \
+                     "Patterns indicate systemic issues requiring architectural attention."
+          }.freeze
+
+          def enrich(gaps)
+            gaps.map { |gap| gap.recommendation ? gap : fill_recommendation(gap) }
+          end
+
+          private
+
+          def fill_recommendation(gap)
+            template = TEMPLATES.fetch(gap.type, "Review %<action>s for improvement opportunities.")
+            rec = format(template, action: gap.action, rate: format_evidence_rate(gap))
+
+            Models::Gap.new(
+              type: gap.type,
+              action: gap.action,
+              severity: gap.severity,
+              evidence: gap.evidence,
+              description: gap.description,
+              recommendation: rec
+            )
+          end
+
+          def format_evidence_rate(gap)
+            evidence = gap.evidence
+            return "unknown" unless evidence.is_a?(Hash)
+
+            rate_key = evidence.keys.grep(/rate/).first
+            return "unknown" unless rate_key
+
+            "#{(evidence[rate_key].to_f * 100).round(1)}%"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/report/builder.rb
+++ b/lib/wild/telemetry/analysis/report/builder.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Report
+        # Orchestrates all analyzers, scoring, and recommendation enrichment
+        # to produce a GapReport from parsed telemetry records.
+        class Builder
+          ANALYZERS = [
+            Analyzers::DenialAnalyzer,
+            Analyzers::FailureAnalyzer,
+            Analyzers::LatencyAnalyzer,
+            Analyzers::UtilizationAnalyzer,
+            Analyzers::CoverageAnalyzer,
+            Analyzers::PatternAnalyzer
+          ].freeze
+
+          attr_reader :records, :config
+
+          def initialize(records:, config: Wild.config.telemetry.analysis)
+            @records = records
+            @config = config
+          end
+
+          def build
+            header = records[:header]
+            typed_records = records.except(:header)
+
+            raw_gaps = run_analyzers(typed_records)
+            scored_gaps = score(raw_gaps)
+            enriched_gaps = enrich(scored_gaps)
+
+            Models::GapReport.new(header: header, gaps: enriched_gaps)
+          end
+
+          private
+
+          def run_analyzers(typed_records)
+            ANALYZERS.flat_map do |analyzer_class|
+              analyzer_class.new(config: config).analyze(typed_records)
+            end
+          end
+
+          def score(gaps)
+            Scoring::SeverityScorer.new(config: config).score_all(gaps)
+          end
+
+          def enrich(gaps)
+            Recommendations::Engine.new.enrich(gaps)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/scoring/priority_ranker.rb
+++ b/lib/wild/telemetry/analysis/scoring/priority_ranker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Scoring
+        # Sorts gaps by severity descending and assigns a rank (1 = most critical).
+        class PriorityRanker
+          def rank(gaps)
+            sorted = gaps.sort
+            sorted.each_with_index.map do |gap, index|
+              { rank: index + 1, gap: gap }
+            end
+          end
+
+          # Returns gaps sorted by severity descending (highest first).
+          def sort(gaps)
+            gaps.sort
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wild/telemetry/analysis/scoring/severity_scorer.rb
+++ b/lib/wild/telemetry/analysis/scoring/severity_scorer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module Scoring
+        # Applies configurable per-type weight adjustments to raw gap severities.
+        class SeverityScorer
+          attr_reader :config
+
+          def initialize(config: Wild.config.telemetry.analysis)
+            @config = config
+          end
+
+          # Returns a new Gap with severity adjusted by the configured weight for its type.
+          def score(gap)
+            weight = config.severity_weights.fetch(gap.type, 1.0)
+            adjusted = (gap.severity * weight).clamp(0.0, 1.0)
+
+            Models::Gap.new(
+              type: gap.type,
+              action: gap.action,
+              severity: adjusted,
+              evidence: gap.evidence,
+              description: gap.description,
+              recommendation: gap.recommendation
+            )
+          end
+
+          def score_all(gaps)
+            gaps.map { |gap| score(gap) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,14 +48,28 @@ require_relative "support/wild_analyzers_permission/fixtures"
 require_relative "support/wild_analyzers_test_flakes/fixtures"
 require_relative "support/wild_telemetry_collector/event_fixtures"
 require_relative "support/wild_telemetry_pipeline/fixtures"
+require_relative "support/wild_telemetry_analysis/telemetry_fixtures"
 
 RSpec.configure do |config|
-  config.include Wild::Hooks::TestSupport::HookFixtures
-  config.include Wild::Skillops::TestSupport::Fixtures
-  config.include Wild::Analyzers::Permission::TestSupport::Fixtures
-  config.include Wild::Analyzers::TestFlakes::TestSupport::Fixtures
-  config.include Wild::Telemetry::Collector::TestSupport::EventFixtures
-  config.include Wild::Telemetry::Pipeline::TestSupport::TranscriptFixtures
+  # Fixture modules are scoped to their own namespace's spec subtree by
+  # file_path. Several modules share helper names (e.g. build_event exists in
+  # both HookFixtures and the telemetry TelemetryFixtures) — a global include
+  # would let the last-loaded module shadow the others. Path-scoping keeps each
+  # namespace's helpers bound to its own specs.
+  config.include Wild::Hooks::TestSupport::HookFixtures,
+                 file_path: %r{spec/wild/hooks/}
+  config.include Wild::Skillops::TestSupport::Fixtures,
+                 file_path: %r{spec/wild/skillops/}
+  config.include Wild::Analyzers::Permission::TestSupport::Fixtures,
+                 file_path: %r{spec/wild/analyzers/permission/}
+  config.include Wild::Analyzers::TestFlakes::TestSupport::Fixtures,
+                 file_path: %r{spec/wild/analyzers/test_flakes/}
+  config.include Wild::Telemetry::Collector::TestSupport::EventFixtures,
+                 file_path: %r{spec/wild/telemetry/collector/}
+  config.include Wild::Telemetry::Pipeline::TestSupport::TranscriptFixtures,
+                 file_path: %r{spec/wild/telemetry/pipeline/}
+  config.include Wild::Telemetry::Analysis::TestSupport::TelemetryFixtures,
+                 file_path: %r{spec/wild/telemetry/analysis/}
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/support/wild_telemetry_analysis/telemetry_fixtures.rb
+++ b/spec/support/wild_telemetry_analysis/telemetry_fixtures.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Wild
+  module Telemetry
+    module Analysis
+      module TestSupport
+        module TelemetryFixtures
+          HEADER_DATA = {
+            "export_type" => "session_telemetry",
+            "schema_version" => "1.0",
+            "exported_at" => "2025-01-15T10:00:00Z",
+            "source_id" => "test-source-001",
+            "time_range" => { "start" => "2025-01-14T00:00:00Z", "end" => "2025-01-15T00:00:00Z" },
+            "record_counts" => { "events" => 100, "summaries" => 5 }
+          }.freeze
+
+          def build_header(overrides = {})
+            Wild::Telemetry::Analysis::Models::ExportHeader.new(HEADER_DATA.merge(overrides))
+          end
+
+          def build_event(overrides = {})
+            data = {
+              "record_type" => "event", "event_type" => "tool_call",
+              "timestamp" => "2025-01-15T10:00:00Z", "caller_id" => "caller-001",
+              "action" => "read_file", "outcome" => "success", "duration_ms" => 50, "metadata" => {}
+            }.merge(overrides)
+            Wild::Telemetry::Analysis::Models::EventRecord.new(data)
+          end
+
+          def build_session_summary(overrides = {})
+            data = {
+              "record_type" => "session_summary", "caller_id" => "caller-001",
+              "event_count" => 10, "distinct_actions" => %w[read_file write_file list_dir],
+              "outcome_breakdown" => { "success" => 8, "denied" => 2 }, "total_duration_ms" => 500
+            }.merge(overrides)
+            Wild::Telemetry::Analysis::Models::SessionSummary.new(data)
+          end
+
+          def build_tool_utilization(overrides = {})
+            data = {
+              "record_type" => "tool_utilization", "action" => "read_file",
+              "invocation_count" => 20, "unique_callers" => 3,
+              "success_rate" => 0.9, "avg_duration_ms" => 45.0
+            }.merge(overrides)
+            Wild::Telemetry::Analysis::Models::ToolUtilization.new(data)
+          end
+
+          def build_outcome_distribution(overrides = {})
+            data = {
+              "record_type" => "outcome_distribution", "action" => "read_file",
+              "total_count" => 20, "outcomes" => { "success" => 0.8, "denied" => 0.1, "error" => 0.1 }
+            }.merge(overrides)
+            Wild::Telemetry::Analysis::Models::OutcomeDistribution.new(data)
+          end
+
+          def build_latency_stats(overrides = {})
+            data = {
+              "record_type" => "latency_stats", "action" => "read_file",
+              "p50_ms" => 100.0, "p95_ms" => 300.0, "p99_ms" => 450.0,
+              "min_ms" => 10.0, "max_ms" => 600.0, "avg_ms" => 120.0, "sample_count" => 50
+            }.merge(overrides)
+            Wild::Telemetry::Analysis::Models::LatencyStats.new(data)
+          end
+
+          def build_pattern_record(overrides = {})
+            data = {
+              "record_type" => "pattern", "pattern_type" => "retry_loop",
+              "sequence" => %w[read_file read_file read_file],
+              "occurrence_count" => 5, "unique_callers" => 2
+            }.merge(overrides)
+            Wild::Telemetry::Analysis::Models::PatternRecord.new(data)
+          end
+
+          def build_gap(overrides = {})
+            defaults = {
+              type: :denial, action: "read_file", severity: 0.5,
+              evidence: { denial_rate: 0.5 }, description: "Test gap description",
+              recommendation: "Test recommendation"
+            }
+            Wild::Telemetry::Analysis::Models::Gap.new(**defaults, **overrides)
+          end
+
+          def minimal_records
+            {
+              outcome_distribution: [build_outcome_distribution],
+              tool_utilization: [build_tool_utilization],
+              latency_stats: [build_latency_stats],
+              session_summary: [build_session_summary],
+              pattern: [build_pattern_record]
+            }
+          end
+
+          def valid_jsonl
+            [HEADER_DATA, valid_jsonl_event, valid_jsonl_utilization, valid_jsonl_distribution]
+              .map { |l| JSON.generate(l) }.join("\n")
+          end
+
+          private
+
+          def valid_jsonl_event
+            { "record_type" => "event", "event_type" => "tool_call",
+              "timestamp" => "2025-01-15T10:00:00Z", "caller_id" => "c1",
+              "action" => "read_file", "outcome" => "success", "duration_ms" => 50 }
+          end
+
+          def valid_jsonl_utilization
+            { "record_type" => "tool_utilization", "action" => "read_file",
+              "invocation_count" => 10, "unique_callers" => 2,
+              "success_rate" => 0.9, "avg_duration_ms" => 50.0 }
+          end
+
+          def valid_jsonl_distribution
+            { "record_type" => "outcome_distribution", "action" => "read_file",
+              "total_count" => 10, "outcomes" => { "success" => 0.9, "denied" => 0.1 } }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/wild/configuration_spec.rb
+++ b/spec/wild/configuration_spec.rb
@@ -124,6 +124,19 @@ RSpec.describe Wild::Configuration do
     it "Analysis defaults gap_threshold to 0.7" do
       expect(telemetry.analysis.gap_threshold).to eq(0.7)
     end
+
+    # Gap-miner thresholds carried from the old wild-gap-miner gem (Role 5
+    # PR-10). Defaults preserved verbatim from the gem's DEFAULTS hash.
+    it "Analysis carries the gap-miner thresholds with their old-gem defaults" do # rubocop:disable RSpec/MultipleExpectations
+      expect(telemetry.analysis.denial_threshold).to eq(0.2)
+      expect(telemetry.analysis.failure_threshold).to eq(0.15)
+      expect(telemetry.analysis.latency_p95_threshold_ms).to eq(500.0)
+      expect(telemetry.analysis.utilization_min_count).to eq(5)
+      expect(telemetry.analysis.coverage_min_fraction).to eq(0.3)
+      expect(telemetry.analysis.pattern_min_occurrences).to eq(3)
+      expect(telemetry.analysis.max_gaps_per_type).to eq(50)
+      expect(telemetry.analysis.severity_weights[:denial]).to eq(1.0)
+    end
   end
 
   describe Wild::Configuration::Hooks do

--- a/spec/wild/telemetry/analysis/adversarial/malformed_input_spec.rb
+++ b/spec/wild/telemetry/analysis/adversarial/malformed_input_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass
+
+RSpec.describe "Adversarial: malformed input handling" do
+  let(:parser) { Wild::Telemetry::Analysis::Ingestion::ExportParser.new }
+
+  describe "parse_string edge cases" do
+    it "raises ParseError for pure whitespace" do
+      expect { parser.parse_string("   \n   \n") }.to raise_error(Wild::Telemetry::Analysis::ParseError)
+    end
+
+    it "raises ParseError when header JSON is truncated" do
+      expect { parser.parse_string('{"export_type":') }.to raise_error(Wild::Telemetry::Analysis::ParseError)
+    end
+
+    it "raises ParseError when a data line has invalid JSON" do
+      header = JSON.generate(Wild::Telemetry::Analysis::TestSupport::TelemetryFixtures::HEADER_DATA)
+      expect { parser.parse_string("#{header}\n{bad json}") }.to raise_error(Wild::Telemetry::Analysis::ParseError)
+    end
+
+    it "raises SchemaError when header missing source_id" do
+      bad_header = JSON.generate("export_type" => "session_telemetry", "schema_version" => "1.0")
+      expect { parser.parse_string(bad_header) }.to raise_error(Wild::Telemetry::Analysis::SchemaError)
+    end
+
+    it "raises SchemaError when export_type does not match" do
+      bad_header = JSON.generate("export_type" => "wrong", "schema_version" => "1.0", "source_id" => "x")
+      expect { parser.parse_string(bad_header) }.to raise_error(Wild::Telemetry::Analysis::SchemaError)
+    end
+
+    it "handles records with missing optional fields gracefully" do
+      header_line = JSON.generate(Wild::Telemetry::Analysis::TestSupport::TelemetryFixtures::HEADER_DATA)
+      minimal_event = JSON.generate("record_type" => "event")
+      result = parser.parse_string("#{header_line}\n#{minimal_event}")
+      expect(result[:records][:event].first).to be_a(Wild::Telemetry::Analysis::Models::EventRecord)
+    end
+
+    it "handles records with null field values" do
+      header_line = JSON.generate(Wild::Telemetry::Analysis::TestSupport::TelemetryFixtures::HEADER_DATA)
+      null_record = JSON.generate(
+        "record_type" => "tool_utilization", "action" => nil,
+        "invocation_count" => nil, "success_rate" => nil
+      )
+      expect { parser.parse_string("#{header_line}\n#{null_record}") }.not_to raise_error
+    end
+
+    it "handles very large JSONL content" do
+      header_line = JSON.generate(Wild::Telemetry::Analysis::TestSupport::TelemetryFixtures::HEADER_DATA)
+      events = Array.new(500) do |i|
+        JSON.generate(
+          "record_type" => "event", "event_type" => "tool_call",
+          "timestamp" => "2025-01-15T10:00:00Z", "caller_id" => "caller-#{i}",
+          "action" => "action_#{i % 10}", "outcome" => "success", "duration_ms" => i
+        )
+      end
+      content = ([header_line] + events).join("\n")
+      result = parser.parse_string(content)
+      expect(result[:records][:event].length).to eq(500)
+    end
+  end
+
+  describe "Gap model adversarial inputs" do
+    it "rejects unknown gap types" do
+      expect { build_gap(type: :totally_unknown) }.to raise_error(Wild::Telemetry::Analysis::ValidationError)
+    end
+
+    it "rejects severity of -0.001" do
+      expect { build_gap(severity: -0.001) }.to raise_error(Wild::Telemetry::Analysis::ValidationError)
+    end
+
+    it "rejects severity of 1.001" do
+      expect { build_gap(severity: 1.001) }.to raise_error(Wild::Telemetry::Analysis::ValidationError)
+    end
+
+    it "coerces integer severity to float" do
+      gap = build_gap(severity: 1)
+      expect(gap.severity).to be_a(Float)
+    end
+  end
+
+  # The old gem's Configuration did per-setter validation + freeze!. Wild's
+  # typed Struct dropped both (no-freeze design); the 8 validation/freeze specs
+  # are deleted rather than rewritten — F3 (no vanity tests of absent behavior).
+
+  describe "Analyzer adversarial inputs" do
+    let(:analyzer) { Wild::Telemetry::Analysis::Analyzers::DenialAnalyzer.new }
+
+    it "handles records hash with nil values gracefully" do
+      records = { outcome_distribution: nil }
+      expect { analyzer.analyze(records) }.not_to raise_error
+    end
+
+    it "returns empty array for completely empty records" do
+      expect(analyzer.analyze({})).to eq([])
+    end
+  end
+
+  describe "ExportParser file edge cases" do
+    it "raises ParseError for nonexistent file" do
+      expect { parser.parse_file("/tmp/__wild_gap_miner_no_such_file__.jsonl") }
+        .to raise_error(Wild::Telemetry::Analysis::ParseError, /file not found/)
+    end
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass

--- a/spec/wild/telemetry/analysis/analysis_spec.rb
+++ b/spec/wild/telemetry/analysis/analysis_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/SpecFilePathFormat
+
+require "tmpdir"
+
+RSpec.describe Wild::Telemetry::Analysis do
+  # F1 collapsed per-gem Configuration accessors into the central
+  # Wild.config.telemetry.analysis block; the old gem-level
+  # .configuration/.configure/.reset_configuration! tests are dropped.
+  # This spec covers the .analyze convenience method + module identity.
+
+  it "defines the Wild::Telemetry::Analysis module" do
+    expect(described_class).to be_a(Module)
+  end
+
+  describe ".analyze" do
+    it "parses a JSONL file and returns a GapReport" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "test.jsonl")
+        File.write(path, valid_jsonl)
+        report = described_class.analyze(path)
+        expect(report).to be_a(Wild::Telemetry::Analysis::Models::GapReport)
+      end
+    end
+
+    it "reads thresholds from Wild.config.telemetry.analysis" do
+      Wild.configure { |c| c.telemetry.analysis.denial_threshold = 0.5 }
+      expect(Wild.config.telemetry.analysis.denial_threshold).to eq(0.5)
+    end
+  end
+end
+
+# rubocop:enable RSpec/SpecFilePathFormat

--- a/spec/wild/telemetry/analysis/analyzers/coverage_analyzer_spec.rb
+++ b/spec/wild/telemetry/analysis/analyzers/coverage_analyzer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Analyzers::CoverageAnalyzer do
+  subject(:analyzer) { described_class.new }
+
+  let(:all_utils) do
+    %w[read_file write_file list_dir delete_file exec_cmd grep_file].map do |action|
+      build_tool_utilization("action" => action, "invocation_count" => 10)
+    end
+  end
+
+  describe "#analyze" do
+    context "when caller uses fewer actions than coverage minimum" do
+      let(:session) { build_session_summary("distinct_actions" => ["read_file"]) }
+      let(:records) { { session_summary: [session], tool_utilization: all_utils } }
+
+      it "returns a coverage gap" do
+        gaps = analyzer.analyze(records)
+        expect(gaps.length).to eq(1)
+      end
+
+      it "sets gap type to :coverage" do
+        gap = analyzer.analyze(records).first
+        expect(gap.type).to eq(:coverage)
+      end
+
+      it "includes coverage_fraction in evidence" do
+        gap = analyzer.analyze(records).first
+        expect(gap.evidence[:coverage_fraction]).to be < 0.3
+      end
+
+      it "uses caller_id as the action label" do
+        gap = analyzer.analyze(records).first
+        expect(gap.action).to eq("caller-001")
+      end
+    end
+
+    context "when caller meets coverage minimum" do
+      let(:session) do
+        build_session_summary("distinct_actions" => %w[read_file write_file list_dir delete_file])
+      end
+      let(:records) { { session_summary: [session], tool_utilization: all_utils } }
+
+      it "returns no gaps" do
+        # 4/6 = 0.667, above 0.3 threshold
+        expect(analyzer.analyze(records)).to be_empty
+      end
+    end
+
+    context "with no session_summary records" do
+      it "returns empty array" do
+        expect(analyzer.analyze({ tool_utilization: all_utils })).to eq([])
+      end
+    end
+
+    context "with no tool_utilization records" do
+      it "returns empty array" do
+        session = build_session_summary
+        expect(analyzer.analyze({ session_summary: [session] })).to eq([])
+      end
+    end
+
+    context "with custom coverage_min_fraction" do
+      it "uses configured minimum" do
+        Wild.configure { |c| c.telemetry.analysis.coverage_min_fraction = 0.8 }
+        analyzer = described_class.new
+        session = build_session_summary("distinct_actions" => %w[read_file write_file list_dir])
+        gaps = analyzer.analyze({ session_summary: [session], tool_utilization: all_utils })
+        expect(gaps).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/analyzers/denial_analyzer_spec.rb
+++ b/spec/wild/telemetry/analysis/analyzers/denial_analyzer_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Analyzers::DenialAnalyzer do
+  subject(:analyzer) { described_class.new }
+
+  describe "#analyze" do
+    context "when denial rate exceeds threshold" do
+      let(:dist) { build_outcome_distribution("outcomes" => { "success" => 0.5, "denied" => 0.5 }) }
+      let(:records) { { outcome_distribution: [dist] } }
+
+      it "returns a denial gap" do
+        gaps = analyzer.analyze(records)
+        expect(gaps.length).to eq(1)
+      end
+
+      it "sets gap type to :denial" do
+        gap = analyzer.analyze(records).first
+        expect(gap.type).to eq(:denial)
+      end
+
+      it "sets severity to the denial rate" do
+        gap = analyzer.analyze(records).first
+        expect(gap.severity).to eq(0.5)
+      end
+
+      it "includes denial_rate in evidence" do
+        gap = analyzer.analyze(records).first
+        expect(gap.evidence[:denial_rate]).to eq(0.5)
+      end
+
+      it "includes a recommendation" do
+        gap = analyzer.analyze(records).first
+        expect(gap.recommendation).not_to be_nil
+      end
+    end
+
+    context "when denial rate is below threshold" do
+      let(:dist) { build_outcome_distribution("outcomes" => { "success" => 0.98, "denied" => 0.02 }) }
+      let(:records) { { outcome_distribution: [dist] } }
+
+      it "returns no gaps" do
+        expect(analyzer.analyze(records)).to be_empty
+      end
+    end
+
+    context "when denial rate exactly equals threshold" do
+      let(:dist) { build_outcome_distribution("outcomes" => { "success" => 0.8, "denied" => 0.2 }) }
+      let(:records) { { outcome_distribution: [dist] } }
+
+      it "returns a gap" do
+        expect(analyzer.analyze(records)).not_to be_empty
+      end
+    end
+
+    context "with no outcome_distribution records" do
+      it "returns empty array" do
+        expect(analyzer.analyze({})).to eq([])
+      end
+    end
+
+    context "when max_gaps_per_type is set" do
+      it "limits to configured maximum" do
+        Wild.configure { |c| c.telemetry.analysis.max_gaps_per_type = 1 }
+        analyzer = described_class.new
+        dists = [
+          build_outcome_distribution("action" => "a", "outcomes" => { "denied" => 0.9 }),
+          build_outcome_distribution("action" => "b", "outcomes" => { "denied" => 0.8 })
+        ]
+        gaps = analyzer.analyze({ outcome_distribution: dists })
+        expect(gaps.length).to be <= 1
+      end
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/analyzers/failure_analyzer_spec.rb
+++ b/spec/wild/telemetry/analysis/analyzers/failure_analyzer_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Analyzers::FailureAnalyzer do
+  subject(:analyzer) { described_class.new }
+
+  describe "#analyze" do
+    context "when failure rate exceeds threshold" do
+      let(:util) { build_tool_utilization("success_rate" => 0.5) }
+      let(:records) { { tool_utilization: [util] } }
+
+      it "returns a failure gap" do
+        gaps = analyzer.analyze(records)
+        expect(gaps.length).to eq(1)
+      end
+
+      it "sets gap type to :failure" do
+        gap = analyzer.analyze(records).first
+        expect(gap.type).to eq(:failure)
+      end
+
+      it "sets severity to the failure rate" do
+        gap = analyzer.analyze(records).first
+        expect(gap.severity).to eq(0.5)
+      end
+
+      it "includes failure_rate in evidence" do
+        gap = analyzer.analyze(records).first
+        expect(gap.evidence[:failure_rate]).to eq(0.5)
+      end
+    end
+
+    context "when failure rate is below threshold" do
+      let(:util) { build_tool_utilization("success_rate" => 0.95) }
+      let(:records) { { tool_utilization: [util] } }
+
+      it "returns no gaps" do
+        expect(analyzer.analyze(records)).to be_empty
+      end
+    end
+
+    context "with no tool_utilization records" do
+      it "returns empty array" do
+        expect(analyzer.analyze({})).to eq([])
+      end
+    end
+
+    context "with custom failure threshold" do
+      it "uses configured threshold" do
+        Wild.configure { |c| c.telemetry.analysis.failure_threshold = 0.4 }
+        analyzer = described_class.new
+        util = build_tool_utilization("success_rate" => 0.7) # failure = 0.3, below 0.4
+        gaps = analyzer.analyze({ tool_utilization: [util] })
+        expect(gaps).to be_empty
+      end
+    end
+
+    context "with 100% failure rate" do
+      let(:util) { build_tool_utilization("success_rate" => 0.0) }
+      let(:records) { { tool_utilization: [util] } }
+
+      it "caps severity at 1.0" do
+        gap = analyzer.analyze(records).first
+        expect(gap.severity).to eq(1.0)
+      end
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/analyzers/latency_analyzer_spec.rb
+++ b/spec/wild/telemetry/analysis/analyzers/latency_analyzer_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Analyzers::LatencyAnalyzer do
+  subject(:analyzer) { described_class.new }
+
+  describe "#analyze" do
+    context "when p95 exceeds threshold" do
+      let(:stat) { build_latency_stats("p95_ms" => 600.0) }
+      let(:records) { { latency_stats: [stat] } }
+
+      it "returns a latency gap" do
+        gaps = analyzer.analyze(records)
+        expect(gaps.length).to eq(1)
+      end
+
+      it "sets gap type to :latency" do
+        gap = analyzer.analyze(records).first
+        expect(gap.type).to eq(:latency)
+      end
+
+      it "includes p95_ms in evidence" do
+        gap = analyzer.analyze(records).first
+        expect(gap.evidence[:p95_ms]).to eq(600.0)
+      end
+
+      it "includes threshold_ms in evidence" do
+        gap = analyzer.analyze(records).first
+        expect(gap.evidence[:threshold_ms]).to eq(500.0)
+      end
+    end
+
+    context "when p95 is below threshold" do
+      let(:stat) { build_latency_stats("p95_ms" => 200.0) }
+      let(:records) { { latency_stats: [stat] } }
+
+      it "returns no gaps" do
+        expect(analyzer.analyze(records)).to be_empty
+      end
+    end
+
+    context "when p95 is exactly at threshold" do
+      let(:stat) { build_latency_stats("p95_ms" => 500.0) }
+      let(:records) { { latency_stats: [stat] } }
+
+      it "returns no gaps" do
+        expect(analyzer.analyze(records)).to be_empty
+      end
+    end
+
+    context "with no latency_stats records" do
+      it "returns empty array" do
+        expect(analyzer.analyze({})).to eq([])
+      end
+    end
+
+    context "with custom latency threshold" do
+      it "uses configured threshold" do
+        Wild.configure { |c| c.telemetry.analysis.latency_p95_threshold_ms = 100.0 }
+        analyzer = described_class.new
+        stat = build_latency_stats("p95_ms" => 150.0)
+        gaps = analyzer.analyze({ latency_stats: [stat] })
+        expect(gaps).not_to be_empty
+      end
+    end
+
+    context "with p95 at 2x threshold (severity saturation)" do
+      let(:stat) { build_latency_stats("p95_ms" => 1000.0) }
+      let(:records) { { latency_stats: [stat] } }
+
+      it "caps severity at 1.0" do
+        gap = analyzer.analyze(records).first
+        expect(gap.severity).to eq(1.0)
+      end
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/analyzers/pattern_analyzer_spec.rb
+++ b/spec/wild/telemetry/analysis/analyzers/pattern_analyzer_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Analyzers::PatternAnalyzer do
+  subject(:analyzer) { described_class.new }
+
+  describe "#analyze" do
+    context "when pattern occurs enough times" do
+      let(:pattern) { build_pattern_record("occurrence_count" => 5) }
+      let(:records) { { pattern: [pattern] } }
+
+      it "returns a pattern gap" do
+        gaps = analyzer.analyze(records)
+        expect(gaps.length).to eq(1)
+      end
+
+      it "sets gap type to :pattern" do
+        gap = analyzer.analyze(records).first
+        expect(gap.type).to eq(:pattern)
+      end
+
+      it "includes pattern_type in evidence" do
+        gap = analyzer.analyze(records).first
+        expect(gap.evidence[:pattern_type]).to eq("retry_loop")
+      end
+
+      it "uses the sequence as the action label" do
+        gap = analyzer.analyze(records).first
+        expect(gap.action).to include("read_file")
+      end
+    end
+
+    context "when occurrence_count is below minimum" do
+      let(:pattern) { build_pattern_record("occurrence_count" => 1) }
+      let(:records) { { pattern: [pattern] } }
+
+      it "returns no gaps" do
+        expect(analyzer.analyze(records)).to be_empty
+      end
+    end
+
+    context "with failure_cascade pattern" do
+      let(:pattern) { build_pattern_record("pattern_type" => "failure_cascade", "occurrence_count" => 5) }
+      let(:records) { { pattern: [pattern] } }
+
+      it "returns a gap with higher base severity" do
+        gap = analyzer.analyze(records).first
+        expect(gap.severity).to be > 0.5
+      end
+
+      it "includes cascade-specific recommendation" do
+        gap = analyzer.analyze(records).first
+        expect(gap.recommendation).to include("cascade")
+      end
+    end
+
+    context "with no pattern records" do
+      it "returns empty array" do
+        expect(analyzer.analyze({})).to eq([])
+      end
+    end
+
+    context "with custom pattern_min_occurrences" do
+      it "uses configured minimum" do
+        Wild.configure { |c| c.telemetry.analysis.pattern_min_occurrences = 10 }
+        analyzer = described_class.new
+        pattern = build_pattern_record("occurrence_count" => 5)
+        gaps = analyzer.analyze({ pattern: [pattern] })
+        expect(gaps).to be_empty
+      end
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/analyzers/utilization_analyzer_spec.rb
+++ b/spec/wild/telemetry/analysis/analyzers/utilization_analyzer_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Analyzers::UtilizationAnalyzer do
+  subject(:analyzer) { described_class.new }
+
+  describe "#analyze" do
+    context "when invocation_count is below minimum" do
+      let(:util) { build_tool_utilization("invocation_count" => 2) }
+      let(:records) { { tool_utilization: [util] } }
+
+      it "returns a utilization gap" do
+        gaps = analyzer.analyze(records)
+        expect(gaps.length).to eq(1)
+      end
+
+      it "sets gap type to :utilization" do
+        gap = analyzer.analyze(records).first
+        expect(gap.type).to eq(:utilization)
+      end
+
+      it "includes invocation_count in evidence" do
+        gap = analyzer.analyze(records).first
+        expect(gap.evidence[:invocation_count]).to eq(2)
+      end
+    end
+
+    context "when invocation_count meets the minimum" do
+      let(:util) { build_tool_utilization("invocation_count" => 10) }
+      let(:records) { { tool_utilization: [util] } }
+
+      it "returns no gaps" do
+        expect(analyzer.analyze(records)).to be_empty
+      end
+    end
+
+    context "when invocation_count is zero" do
+      let(:util) { build_tool_utilization("invocation_count" => 0) }
+      let(:records) { { tool_utilization: [util] } }
+
+      it "returns a gap with severity 1.0" do
+        gap = analyzer.analyze(records).first
+        expect(gap.severity).to eq(1.0)
+      end
+    end
+
+    context "with no tool_utilization records" do
+      it "returns empty array" do
+        expect(analyzer.analyze({})).to eq([])
+      end
+    end
+
+    context "with custom utilization min count" do
+      it "uses configured min count" do
+        Wild.configure { |c| c.telemetry.analysis.utilization_min_count = 20 }
+        analyzer = described_class.new
+        util = build_tool_utilization("invocation_count" => 15)
+        gaps = analyzer.analyze({ tool_utilization: [util] })
+        expect(gaps).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/export/json_exporter_spec.rb
+++ b/spec/wild/telemetry/analysis/export/json_exporter_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Export::JsonExporter do
+  subject(:exporter) { described_class.new }
+
+  let(:report) do
+    Wild::Telemetry::Analysis::Models::GapReport.new(
+      header: build_header,
+      gaps: [build_gap(severity: 0.7)],
+      generated_at: "2025-01-15T10:00:00Z"
+    )
+  end
+
+  describe "#export" do
+    it "returns a JSON string" do
+      json = exporter.export(report)
+      expect { JSON.parse(json) }.not_to raise_error
+    end
+
+    it "includes header data" do
+      parsed = JSON.parse(exporter.export(report))
+      expect(parsed["header"]).not_to be_nil
+    end
+
+    it "includes gaps array" do
+      parsed = JSON.parse(exporter.export(report))
+      expect(parsed["gaps"]).to be_an(Array)
+    end
+
+    it "includes generated_at" do
+      parsed = JSON.parse(exporter.export(report))
+      expect(parsed["generated_at"]).to eq("2025-01-15T10:00:00Z")
+    end
+
+    it "includes summary" do
+      parsed = JSON.parse(exporter.export(report))
+      expect(parsed["summary"]).to include("total_gaps")
+    end
+  end
+
+  describe "#write" do
+    it "writes JSON to file and returns path" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "report.json")
+        result = exporter.write(report, path)
+        expect(result).to eq(path)
+        expect(File.exist?(path)).to be(true)
+      end
+    end
+
+    it "writes valid JSON" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "report.json")
+        exporter.write(report, path)
+        expect { JSON.parse(File.read(path)) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/export/markdown_exporter_spec.rb
+++ b/spec/wild/telemetry/analysis/export/markdown_exporter_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Export::MarkdownExporter do
+  subject(:exporter) { described_class.new }
+
+  let(:report) do
+    Wild::Telemetry::Analysis::Models::GapReport.new(
+      header: build_header,
+      gaps: [
+        build_gap(type: :denial, severity: 0.9, action: "tool_a", description: "High denial rate"),
+        build_gap(type: :failure, severity: 0.5, action: "tool_b", description: "Medium failure")
+      ],
+      generated_at: "2025-01-15T10:00:00Z"
+    )
+  end
+
+  describe "#export" do
+    it "returns a String" do
+      expect(exporter.export(report)).to be_a(String)
+    end
+
+    it "starts with a heading" do
+      expect(exporter.export(report)).to start_with("# Gap Analysis Report")
+    end
+
+    it "includes Generated timestamp" do
+      expect(exporter.export(report)).to include("2025-01-15T10:00:00Z")
+    end
+
+    it "includes Summary section" do
+      expect(exporter.export(report)).to include("## Summary")
+    end
+
+    it "includes Gaps section" do
+      expect(exporter.export(report)).to include("## Gaps")
+    end
+
+    it "includes gap action in output" do
+      expect(exporter.export(report)).to include("tool_a")
+    end
+
+    it "shows HIGH for high severity gap" do
+      expect(exporter.export(report)).to include("[HIGH]")
+    end
+
+    it "shows MEDIUM for medium severity gap" do
+      expect(exporter.export(report)).to include("[MEDIUM]")
+    end
+
+    it "shows evidence section" do
+      expect(exporter.export(report)).to include("**Evidence**")
+    end
+  end
+
+  describe "with empty report" do
+    let(:empty_report) do
+      Wild::Telemetry::Analysis::Models::GapReport.new(header: build_header, gaps: [])
+    end
+
+    it "shows no gaps detected message" do
+      expect(exporter.export(empty_report)).to include("No gaps detected")
+    end
+  end
+
+  describe "#write" do
+    it "writes markdown to file and returns path" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "report.md")
+        result = exporter.write(report, path)
+        expect(result).to eq(path)
+        expect(File.exist?(path)).to be(true)
+      end
+    end
+
+    it "writes readable markdown content" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "report.md")
+        exporter.write(report, path)
+        content = File.read(path)
+        expect(content).to include("# Gap Analysis Report")
+      end
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/ingestion/export_parser_spec.rb
+++ b/spec/wild/telemetry/analysis/ingestion/export_parser_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Ingestion::ExportParser do
+  subject(:parser) { described_class.new }
+
+  describe "#parse_string" do
+    it "returns a hash with header and records" do
+      result = parser.parse_string(valid_jsonl)
+      expect(result).to include(:header, :records)
+    end
+
+    it "parses the header as ExportHeader" do
+      result = parser.parse_string(valid_jsonl)
+      expect(result[:header]).to be_a(Wild::Telemetry::Analysis::Models::ExportHeader)
+    end
+
+    it "groups records by record_type symbol" do
+      result = parser.parse_string(valid_jsonl)
+      expect(result[:records]).to be_a(Hash)
+      expect(result[:records][:event]).not_to be_nil
+    end
+
+    it "raises ParseError for invalid JSON" do
+      bad_jsonl = "{\"export_type\":\"session_telemetry\",\"schema_version\":\"1.0\",\"source_id\":\"x\"}\n{not json}"
+      expect { parser.parse_string(bad_jsonl) }.to raise_error(Wild::Telemetry::Analysis::ParseError)
+    end
+
+    it "raises ParseError for empty content" do
+      expect { parser.parse_string("") }.to raise_error(Wild::Telemetry::Analysis::ParseError, /empty/)
+    end
+
+    it "raises SchemaError when header is invalid" do
+      bad_header = JSON.generate({ "export_type" => "wrong", "schema_version" => "1.0" })
+      expect { parser.parse_string(bad_header) }.to raise_error(Wild::Telemetry::Analysis::SchemaError)
+    end
+
+    it "ignores blank lines" do
+      jsonl_with_blanks = valid_jsonl.gsub("\n", "\n\n")
+      expect { parser.parse_string(jsonl_with_blanks) }.not_to raise_error
+    end
+
+    it "parses multiple record types" do
+      result = parser.parse_string(valid_jsonl)
+      expect(result[:records].keys).to include(:event, :tool_utilization, :outcome_distribution)
+    end
+  end
+
+  describe "#parse_file" do
+    it "raises ParseError when file does not exist" do
+      expect { parser.parse_file("/tmp/nonexistent_wild_gap_miner_test.jsonl") }
+        .to raise_error(Wild::Telemetry::Analysis::ParseError, /file not found/)
+    end
+
+    it "parses a valid file" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "test.jsonl")
+        File.write(path, valid_jsonl)
+        result = parser.parse_file(path)
+        expect(result[:header]).to be_valid
+      end
+    end
+
+    it "raises ParseError for empty file" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "empty.jsonl")
+        File.write(path, "")
+        expect { parser.parse_file(path) }.to raise_error(Wild::Telemetry::Analysis::ParseError, /empty/)
+      end
+    end
+  end
+
+  describe "with custom config" do
+    it "accepts a config object" do
+      config = Wild::Configuration::Telemetry::Analysis.new
+      p = described_class.new(config: config)
+      expect(p.config).to be(config)
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/ingestion/record_factory_spec.rb
+++ b/spec/wild/telemetry/analysis/ingestion/record_factory_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Ingestion::RecordFactory do
+  describe ".build" do
+    it "builds an EventRecord for record_type event" do
+      record = described_class.build("record_type" => "event", "action" => "x", "outcome" => "success")
+      expect(record).to be_a(Wild::Telemetry::Analysis::Models::EventRecord)
+    end
+
+    it "builds a SessionSummary for record_type session_summary" do
+      record = described_class.build("record_type" => "session_summary", "caller_id" => "c1")
+      expect(record).to be_a(Wild::Telemetry::Analysis::Models::SessionSummary)
+    end
+
+    it "builds a ToolUtilization for record_type tool_utilization" do
+      record = described_class.build("record_type" => "tool_utilization", "action" => "x")
+      expect(record).to be_a(Wild::Telemetry::Analysis::Models::ToolUtilization)
+    end
+
+    it "builds an OutcomeDistribution for record_type outcome_distribution" do
+      record = described_class.build("record_type" => "outcome_distribution", "action" => "x")
+      expect(record).to be_a(Wild::Telemetry::Analysis::Models::OutcomeDistribution)
+    end
+
+    it "builds a LatencyStats for record_type latency_stats" do
+      record = described_class.build("record_type" => "latency_stats", "action" => "x")
+      expect(record).to be_a(Wild::Telemetry::Analysis::Models::LatencyStats)
+    end
+
+    it "builds a PatternRecord for record_type pattern" do
+      record = described_class.build("record_type" => "pattern", "pattern_type" => "loop")
+      expect(record).to be_a(Wild::Telemetry::Analysis::Models::PatternRecord)
+    end
+
+    it "builds a TelemetryRecord for unknown record_type" do
+      record = described_class.build("record_type" => "unknown_type")
+      expect(record).to be_a(Wild::Telemetry::Analysis::Models::TelemetryRecord)
+    end
+
+    it "sets record_type on the built record" do
+      record = described_class.build("record_type" => "event", "action" => "x", "outcome" => "success")
+      expect(record.record_type).to eq("event")
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/integration/full_pipeline_spec.rb
+++ b/spec/wild/telemetry/analysis/integration/full_pipeline_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass, Layout/LineLength
+
+RSpec.describe "Full pipeline integration" do
+  let(:jsonl_content) do
+    lines = [
+      {
+        "export_type" => "session_telemetry",
+        "schema_version" => "1.0",
+        "source_id" => "integration-test",
+        "exported_at" => "2025-01-15T10:00:00Z",
+        "time_range" => { "start" => "2025-01-14T00:00:00Z", "end" => "2025-01-15T00:00:00Z" },
+        "record_counts" => {}
+      },
+      # Events
+      { "record_type" => "event", "event_type" => "tool_call", "timestamp" => "2025-01-15T10:00:00Z",
+        "caller_id" => "caller-1", "action" => "read_file", "outcome" => "success", "duration_ms" => 50 },
+      { "record_type" => "event", "event_type" => "tool_call", "timestamp" => "2025-01-15T10:00:01Z",
+        "caller_id" => "caller-1", "action" => "write_file", "outcome" => "denied", "duration_ms" => 10 },
+      # Tool utilization - high failure
+      { "record_type" => "tool_utilization", "action" => "exec_command",
+        "invocation_count" => 50, "unique_callers" => 3, "success_rate" => 0.2, "avg_duration_ms" => 300.0 },
+      { "record_type" => "tool_utilization", "action" => "read_file",
+        "invocation_count" => 100, "unique_callers" => 5, "success_rate" => 0.95, "avg_duration_ms" => 50.0 },
+      { "record_type" => "tool_utilization", "action" => "write_file",
+        "invocation_count" => 2, "unique_callers" => 1, "success_rate" => 0.5, "avg_duration_ms" => 80.0 },
+      # Outcome distributions - high denial
+      { "record_type" => "outcome_distribution", "action" => "write_file",
+        "total_count" => 10,
+        "outcomes" => { "success" => 0.5, "denied" => 0.5 } },
+      { "record_type" => "outcome_distribution", "action" => "read_file",
+        "total_count" => 100,
+        "outcomes" => { "success" => 0.95, "denied" => 0.05 } },
+      # Latency stats - slow action
+      { "record_type" => "latency_stats", "action" => "exec_command",
+        "p50_ms" => 200.0, "p95_ms" => 900.0, "p99_ms" => 1200.0,
+        "min_ms" => 50.0, "max_ms" => 2000.0, "avg_ms" => 250.0, "sample_count" => 50 },
+      # Session summary - low coverage
+      { "record_type" => "session_summary", "caller_id" => "caller-1",
+        "event_count" => 5, "distinct_actions" => ["read_file"],
+        "outcome_breakdown" => { "success" => 4, "denied" => 1 }, "total_duration_ms" => 500 },
+      # Pattern - failure cascade
+      { "record_type" => "pattern", "pattern_type" => "failure_cascade",
+        "sequence" => %w[exec_command exec_command exec_command],
+        "occurrence_count" => 8, "unique_callers" => 2 }
+    ]
+    lines.map { |l| JSON.generate(l) }.join("\n")
+  end
+
+  it "processes a JSONL string and returns a GapReport" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    expect(report).to be_a(Wild::Telemetry::Analysis::Models::GapReport)
+  end
+
+  it "detects denial gaps" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    expect(report.gaps_of_type(:denial)).not_to be_empty
+  end
+
+  it "detects failure gaps" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    expect(report.gaps_of_type(:failure)).not_to be_empty
+  end
+
+  it "detects latency gaps" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    expect(report.gaps_of_type(:latency)).not_to be_empty
+  end
+
+  it "detects pattern gaps" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    expect(report.gaps_of_type(:pattern)).not_to be_empty
+  end
+
+  it "exports to JSON without errors" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    exporter = Wild::Telemetry::Analysis::Export::JsonExporter.new
+    expect { JSON.parse(exporter.export(report)) }.not_to raise_error
+  end
+
+  it "exports to Markdown without errors" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    exporter = Wild::Telemetry::Analysis::Export::MarkdownExporter.new
+    md = exporter.export(report)
+    expect(md).to include("# Gap Analysis Report")
+  end
+
+  it "uses the convenience Wild::Telemetry::Analysis.analyze method via file" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "integration.jsonl")
+      File.write(path, jsonl_content)
+      report = Wild::Telemetry::Analysis.analyze(path)
+      expect(report).to be_a(Wild::Telemetry::Analysis::Models::GapReport)
+      expect(report.gaps).not_to be_empty
+    end
+  end
+
+  it "gap severities are all within [0.0, 1.0]" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    expect(report.gaps.map(&:severity)).to all(be_between(0.0, 1.0))
+  end
+
+  it "all gaps have recommendations" do
+    parser = Wild::Telemetry::Analysis::Ingestion::ExportParser.new
+    parsed = parser.parse_string(jsonl_content)
+    report = Wild::Telemetry::Analysis::Report::Builder.new(records: parsed[:records].merge(header: parsed[:header])).build
+    expect(report.gaps.map(&:recommendation)).to all(be_a(String).and(satisfy { |s| !s.empty? }))
+  end
+end
+
+# rubocop:enable RSpec/DescribeClass, Layout/LineLength

--- a/spec/wild/telemetry/analysis/models/event_record_spec.rb
+++ b/spec/wild/telemetry/analysis/models/event_record_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::EventRecord do
+  subject(:event) { build_event }
+
+  describe "attribute readers" do
+    it "exposes event_type" do
+      expect(event.event_type).to eq("tool_call")
+    end
+
+    it "exposes caller_id" do
+      expect(event.caller_id).to eq("caller-001")
+    end
+
+    it "exposes action" do
+      expect(event.action).to eq("read_file")
+    end
+
+    it "exposes outcome" do
+      expect(event.outcome).to eq("success")
+    end
+
+    it "exposes duration_ms" do
+      expect(event.duration_ms).to eq(50)
+    end
+
+    it "defaults metadata to empty hash" do
+      e = build_event("metadata" => nil)
+      expect(e.metadata).to eq({})
+    end
+  end
+
+  describe "#success?" do
+    it "returns true when outcome is success" do
+      expect(event).to be_success
+    end
+
+    it "returns false when outcome is denied" do
+      expect(build_event("outcome" => "denied")).not_to be_success
+    end
+  end
+
+  describe "#denied?" do
+    it "returns true when outcome is denied" do
+      expect(build_event("outcome" => "denied")).to be_denied
+    end
+
+    it "returns false when outcome is success" do
+      expect(event).not_to be_denied
+    end
+  end
+
+  describe "#error?" do
+    it "returns true when outcome is error" do
+      expect(build_event("outcome" => "error")).to be_error
+    end
+
+    it "returns false for success" do
+      expect(event).not_to be_error
+    end
+  end
+
+  describe "#rate_limited?" do
+    it "returns true when outcome is rate_limited" do
+      expect(build_event("outcome" => "rate_limited")).to be_rate_limited
+    end
+
+    it "returns false for success" do
+      expect(event).not_to be_rate_limited
+    end
+  end
+
+  describe "record_type" do
+    it "is event" do
+      expect(event.record_type).to eq("event")
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/models/export_header_spec.rb
+++ b/spec/wild/telemetry/analysis/models/export_header_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::ExportHeader do
+  subject(:header) { build_header }
+
+  describe "#valid?" do
+    it "returns true for a complete header" do
+      expect(header).to be_valid
+    end
+
+    it "returns false when export_type is wrong" do
+      expect(build_header("export_type" => "wrong")).not_to be_valid
+    end
+
+    it "returns false when schema_version is missing" do
+      expect(build_header("schema_version" => nil)).not_to be_valid
+    end
+
+    it "returns false when source_id is missing" do
+      expect(build_header("source_id" => nil)).not_to be_valid
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash with all fields" do
+      h = header.to_h
+      expect(h).to include(:export_type, :schema_version, :source_id, :time_range, :record_counts)
+    end
+  end
+
+  describe "attribute readers" do
+    it "exposes export_type" do
+      expect(header.export_type).to eq("session_telemetry")
+    end
+
+    it "exposes schema_version" do
+      expect(header.schema_version).to eq("1.0")
+    end
+
+    it "exposes source_id" do
+      expect(header.source_id).to eq("test-source-001")
+    end
+
+    it "defaults time_range to empty hash" do
+      h = described_class.new("export_type" => "session_telemetry", "schema_version" => "1.0", "source_id" => "x")
+      expect(h.time_range).to eq({})
+    end
+
+    it "defaults record_counts to empty hash" do
+      h = described_class.new("export_type" => "session_telemetry", "schema_version" => "1.0", "source_id" => "x")
+      expect(h.record_counts).to eq({})
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/models/gap_report_spec.rb
+++ b/spec/wild/telemetry/analysis/models/gap_report_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::GapReport do
+  subject(:report) { described_class.new(header: header, gaps: gaps) }
+
+  let(:header) { build_header }
+  let(:gaps) do
+    [
+      build_gap(type: :denial, action: "tool_a", severity: 0.8),
+      build_gap(type: :failure, action: "tool_b", severity: 0.6),
+      build_gap(type: :latency, action: "tool_a", severity: 0.9)
+    ]
+  end
+
+  describe "#gaps" do
+    it "sorts gaps by severity descending" do
+      severities = report.gaps.map(&:severity)
+      expect(severities).to eq(severities.sort.reverse)
+    end
+  end
+
+  describe "#gaps_of_type" do
+    it "returns only gaps of the specified type" do
+      denial_gaps = report.gaps_of_type(:denial)
+      expect(denial_gaps.map(&:type).uniq).to eq([:denial])
+    end
+
+    it "returns empty array when no gaps of that type" do
+      expect(report.gaps_of_type(:pattern)).to eq([])
+    end
+  end
+
+  describe "#summary" do
+    it "includes total_gaps" do
+      expect(report.summary[:total_gaps]).to eq(3)
+    end
+
+    it "includes by_type counts" do
+      expect(report.summary[:by_type][:denial]).to eq(1)
+    end
+
+    it "includes severity_avg" do
+      expect(report.summary[:severity_avg]).to be_a(Float)
+    end
+
+    it "includes high_severity_count" do
+      expect(report.summary[:high_severity_count]).to eq(2) # 0.8 and 0.9
+    end
+
+    it "includes top_actions" do
+      top = report.summary[:top_actions]
+      expect(top).to be_an(Array)
+      expect(top.first[:action]).to eq("tool_a")
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash with header, gaps, summary, and generated_at" do
+      h = report.to_h
+      expect(h.keys).to include(:header, :gaps, :summary, :generated_at)
+    end
+
+    it "serializes gaps as hashes" do
+      expect(report.to_h[:gaps].first).to be_a(Hash)
+    end
+  end
+
+  describe "with empty gaps" do
+    subject(:empty_report) { described_class.new(header: header, gaps: []) }
+
+    it "has severity_avg of 0.0" do
+      expect(empty_report.summary[:severity_avg]).to eq(0.0)
+    end
+
+    it "has empty top_actions" do
+      expect(empty_report.summary[:top_actions]).to eq([])
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/models/gap_spec.rb
+++ b/spec/wild/telemetry/analysis/models/gap_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::Gap do
+  subject(:gap) { build_gap }
+
+  describe "initialization" do
+    it "coerces type to symbol" do
+      g = build_gap(type: "denial")
+      expect(g.type).to eq(:denial)
+    end
+
+    it "coerces action to string" do
+      g = build_gap(action: :read_file)
+      expect(g.action).to eq("read_file")
+    end
+
+    it "coerces severity to float" do
+      g = build_gap(severity: 1)
+      expect(g.severity).to be_a(Float)
+    end
+
+    it "accepts all valid types" do
+      Wild::Telemetry::Analysis::Models::Gap::VALID_TYPES.each do |type|
+        expect { build_gap(type: type) }.not_to raise_error
+      end
+    end
+
+    it "raises ValidationError for unknown type" do
+      expect { build_gap(type: :unknown) }.to raise_error(Wild::Telemetry::Analysis::ValidationError)
+    end
+
+    it "raises ValidationError when severity is below 0" do
+      expect { build_gap(severity: -0.1) }.to raise_error(Wild::Telemetry::Analysis::ValidationError)
+    end
+
+    it "raises ValidationError when severity exceeds 1" do
+      expect { build_gap(severity: 1.1) }.to raise_error(Wild::Telemetry::Analysis::ValidationError)
+    end
+
+    it "accepts severity of exactly 0.0" do
+      expect { build_gap(severity: 0.0) }.not_to raise_error
+    end
+
+    it "accepts severity of exactly 1.0" do
+      expect { build_gap(severity: 1.0) }.not_to raise_error
+    end
+
+    it "allows nil recommendation" do
+      g = build_gap(recommendation: nil)
+      expect(g.recommendation).to be_nil
+    end
+  end
+
+  describe "#to_h" do
+    it "includes all fields" do
+      h = gap.to_h
+      expect(h.keys).to include(:type, :action, :severity, :evidence, :description, :recommendation)
+    end
+  end
+
+  describe "Comparable / sorting" do
+    it "sorts higher severity first" do
+      low = build_gap(severity: 0.2)
+      high = build_gap(severity: 0.8)
+      expect([low, high].sort).to eq([high, low])
+    end
+
+    it "returns -1 when current gap has higher severity" do
+      g1 = build_gap(severity: 0.9)
+      g2 = build_gap(severity: 0.5)
+      expect(g1 <=> g2).to eq(-1)
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/models/latency_stats_spec.rb
+++ b/spec/wild/telemetry/analysis/models/latency_stats_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::LatencyStats do
+  subject(:stat) { build_latency_stats }
+
+  describe "attribute readers" do
+    it "exposes action" do
+      expect(stat.action).to eq("read_file")
+    end
+
+    it "reads p50 from p50_ms key" do
+      expect(stat.p50).to eq(100.0)
+    end
+
+    it "reads p95 from p95_ms key" do
+      expect(stat.p95).to eq(300.0)
+    end
+
+    it "reads p99 from p99_ms key" do
+      expect(stat.p99).to eq(450.0)
+    end
+
+    it "reads min from min_ms key" do
+      expect(stat.min).to eq(10.0)
+    end
+
+    it "reads max from max_ms key" do
+      expect(stat.max).to eq(600.0)
+    end
+
+    it "reads avg from avg_ms key" do
+      expect(stat.avg).to eq(120.0)
+    end
+
+    it "exposes sample_count" do
+      expect(stat.sample_count).to eq(50)
+    end
+
+    it "falls back to bare key if _ms key absent" do
+      s = described_class.new("record_type" => "latency_stats", "action" => "x", "p95" => 200.0)
+      expect(s.p95).to eq(200.0)
+    end
+  end
+
+  describe "record_type" do
+    it "is latency_stats" do
+      expect(stat.record_type).to eq("latency_stats")
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/models/outcome_distribution_spec.rb
+++ b/spec/wild/telemetry/analysis/models/outcome_distribution_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::OutcomeDistribution do
+  subject(:dist) { build_outcome_distribution }
+
+  describe "attribute readers" do
+    it "exposes action" do
+      expect(dist.action).to eq("read_file")
+    end
+
+    it "exposes total_count" do
+      expect(dist.total_count).to eq(20)
+    end
+
+    it "accepts outcomes key from upstream contract" do
+      d = build_outcome_distribution("outcomes" => { "success" => 0.9 })
+      expect(d.distribution["success"]).to eq(0.9)
+    end
+
+    it "defaults distribution to empty hash" do
+      d = described_class.new("record_type" => "outcome_distribution", "action" => "x")
+      expect(d.distribution).to eq({})
+    end
+  end
+
+  describe "#percentage_for" do
+    it "returns the value for a known outcome" do
+      expect(dist.percentage_for("success")).to eq(0.8)
+    end
+
+    it "returns 0.0 for unknown outcomes" do
+      expect(dist.percentage_for("preview")).to eq(0.0)
+    end
+
+    it "accepts symbol keys" do
+      expect(dist.percentage_for(:denied)).to eq(0.1)
+    end
+  end
+
+  describe "record_type" do
+    it "is outcome_distribution" do
+      expect(dist.record_type).to eq("outcome_distribution")
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/models/pattern_record_spec.rb
+++ b/spec/wild/telemetry/analysis/models/pattern_record_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::PatternRecord do
+  subject(:pattern) { build_pattern_record }
+
+  describe "attribute readers" do
+    it "exposes pattern_type" do
+      expect(pattern.pattern_type).to eq("retry_loop")
+    end
+
+    it "exposes sequence" do
+      expect(pattern.sequence).to eq(%w[read_file read_file read_file])
+    end
+
+    it "exposes occurrence_count" do
+      expect(pattern.occurrence_count).to eq(5)
+    end
+
+    it "reads callers_affected from unique_callers key" do
+      expect(pattern.callers_affected).to eq(2)
+    end
+
+    it "falls back to callers_affected key" do
+      p = described_class.new(
+        "record_type" => "pattern", "pattern_type" => "x",
+        "sequence" => [], "occurrence_count" => 1, "callers_affected" => 3
+      )
+      expect(p.callers_affected).to eq(3)
+    end
+
+    it "defaults sequence to empty array" do
+      p = build_pattern_record("sequence" => nil)
+      expect(p.sequence).to eq([])
+    end
+  end
+
+  describe "#failure_cascade?" do
+    it "returns true for failure_cascade pattern type" do
+      p = build_pattern_record("pattern_type" => "failure_cascade")
+      expect(p).to be_failure_cascade
+    end
+
+    it "returns false for other pattern types" do
+      expect(pattern).not_to be_failure_cascade
+    end
+  end
+
+  describe "record_type" do
+    it "is pattern" do
+      expect(pattern.record_type).to eq("pattern")
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/models/session_summary_spec.rb
+++ b/spec/wild/telemetry/analysis/models/session_summary_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::SessionSummary do
+  subject(:summary) { build_session_summary }
+
+  describe "attribute readers" do
+    it "exposes caller_id" do
+      expect(summary.caller_id).to eq("caller-001")
+    end
+
+    it "exposes event_count" do
+      expect(summary.event_count).to eq(10)
+    end
+
+    it "exposes distinct_actions" do
+      expect(summary.distinct_actions).to eq(%w[read_file write_file list_dir])
+    end
+
+    it "exposes outcome_breakdown" do
+      expect(summary.outcome_breakdown).to eq({ "success" => 8, "denied" => 2 })
+    end
+
+    it "defaults event_count to 0" do
+      expect(build_session_summary("event_count" => nil).event_count).to eq(0)
+    end
+
+    it "defaults distinct_actions to empty array" do
+      expect(build_session_summary("distinct_actions" => nil).distinct_actions).to eq([])
+    end
+  end
+
+  describe "#action_count" do
+    it "returns the number of distinct actions" do
+      expect(summary.action_count).to eq(3)
+    end
+
+    it "returns 0 when no distinct actions" do
+      expect(build_session_summary("distinct_actions" => []).action_count).to eq(0)
+    end
+  end
+
+  describe "record_type" do
+    it "is session_summary" do
+      expect(summary.record_type).to eq("session_summary")
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/models/tool_utilization_spec.rb
+++ b/spec/wild/telemetry/analysis/models/tool_utilization_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Models::ToolUtilization do
+  subject(:util) { build_tool_utilization }
+
+  describe "attribute readers" do
+    it "exposes action" do
+      expect(util.action).to eq("read_file")
+    end
+
+    it "exposes invocation_count" do
+      expect(util.invocation_count).to eq(20)
+    end
+
+    it "exposes unique_callers" do
+      expect(util.unique_callers).to eq(3)
+    end
+
+    it "exposes success_rate" do
+      expect(util.success_rate).to eq(0.9)
+    end
+
+    it "exposes avg_duration_ms" do
+      expect(util.avg_duration_ms).to eq(45.0)
+    end
+
+    it "defaults invocation_count to 0" do
+      expect(build_tool_utilization("invocation_count" => nil).invocation_count).to eq(0)
+    end
+
+    it "defaults success_rate to 0.0" do
+      expect(build_tool_utilization("success_rate" => nil).success_rate).to eq(0.0)
+    end
+  end
+
+  describe "record_type" do
+    it "is tool_utilization" do
+      expect(util.record_type).to eq("tool_utilization")
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/recommendations/engine_spec.rb
+++ b/spec/wild/telemetry/analysis/recommendations/engine_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Recommendations::Engine do
+  subject(:engine) { described_class.new }
+
+  describe "#enrich" do
+    context "when gap already has a recommendation" do
+      let(:gap) { build_gap(recommendation: "Existing recommendation") }
+
+      it "preserves the existing recommendation" do
+        enriched = engine.enrich([gap])
+        expect(enriched.first.recommendation).to eq("Existing recommendation")
+      end
+    end
+
+    context "when gap has no recommendation" do
+      let(:gap) { build_gap(recommendation: nil) }
+
+      it "fills in a recommendation" do
+        enriched = engine.enrich([gap])
+        expect(enriched.first.recommendation).not_to be_nil
+      end
+
+      it "uses the gap type in the recommendation" do
+        enriched = engine.enrich([gap])
+        expect(enriched.first.recommendation).not_to be_empty
+      end
+    end
+
+    it "handles each gap type" do
+      Wild::Telemetry::Analysis::Models::Gap::VALID_TYPES.each do |type|
+        gap = build_gap(type: type, recommendation: nil)
+        enriched = engine.enrich([gap])
+        expect(enriched.first.recommendation).not_to be_nil
+      end
+    end
+
+    it "returns the same number of gaps" do
+      gaps = [build_gap(recommendation: nil), build_gap(recommendation: "set")]
+      expect(engine.enrich(gaps).length).to eq(2)
+    end
+
+    it "returns empty array for empty input" do
+      expect(engine.enrich([])).to eq([])
+    end
+
+    it "preserves all other gap fields" do
+      gap = build_gap(type: :failure, action: "my_action", severity: 0.7, recommendation: nil)
+      enriched = engine.enrich([gap]).first
+      expect(enriched.action).to eq("my_action")
+      expect(enriched.severity).to eq(0.7)
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/report/builder_spec.rb
+++ b/spec/wild/telemetry/analysis/report/builder_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Report::Builder do
+  subject(:builder) { described_class.new(records: records) }
+
+  let(:header) { build_header }
+  let(:records) do
+    {
+      header: header,
+      outcome_distribution: [
+        build_outcome_distribution("action" => "high_denial", "outcomes" => { "denied" => 0.8, "success" => 0.2 })
+      ],
+      tool_utilization: [
+        build_tool_utilization("action" => "low_success", "success_rate" => 0.5, "invocation_count" => 10)
+      ],
+      latency_stats: [
+        build_latency_stats("action" => "slow_action", "p95_ms" => 800.0)
+      ],
+      session_summary: [build_session_summary],
+      pattern: [build_pattern_record]
+    }
+  end
+
+  describe "#build" do
+    it "returns a GapReport" do
+      report = builder.build
+      expect(report).to be_a(Wild::Telemetry::Analysis::Models::GapReport)
+    end
+
+    it "populates gaps from all analyzers" do
+      report = builder.build
+      expect(report.gaps).not_to be_empty
+    end
+
+    it "includes denial gaps" do
+      report = builder.build
+      expect(report.gaps_of_type(:denial)).not_to be_empty
+    end
+
+    it "includes failure gaps" do
+      report = builder.build
+      expect(report.gaps_of_type(:failure)).not_to be_empty
+    end
+
+    it "includes latency gaps" do
+      report = builder.build
+      expect(report.gaps_of_type(:latency)).not_to be_empty
+    end
+
+    it "passes the header to the GapReport" do
+      report = builder.build
+      expect(report.header).to eq(header)
+    end
+
+    it "gaps are scored" do
+      report = builder.build
+      expect(report.gaps.map(&:severity)).to all(be_between(0.0, 1.0))
+    end
+
+    it "all gaps have recommendations" do
+      report = builder.build
+      expect(report.gaps.map(&:recommendation)).to all(be_a(String))
+    end
+  end
+
+  describe "with empty records" do
+    subject(:empty_builder) { described_class.new(records: { header: header }) }
+
+    it "returns a GapReport with no gaps" do
+      report = empty_builder.build
+      expect(report.gaps).to be_empty
+    end
+  end
+
+  describe "with custom config" do
+    it "passes config to analyzers" do
+      Wild.configure { |c| c.telemetry.analysis.failure_threshold = 0.9 }
+      builder = described_class.new(records: records)
+      report = builder.build
+      # With 90% failure threshold, the 50% failure rate won't trigger
+      expect(report.gaps_of_type(:failure)).to be_empty
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/scoring/priority_ranker_spec.rb
+++ b/spec/wild/telemetry/analysis/scoring/priority_ranker_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Scoring::PriorityRanker do
+  subject(:ranker) { described_class.new }
+
+  let(:gaps) do
+    [
+      build_gap(severity: 0.3),
+      build_gap(severity: 0.9),
+      build_gap(severity: 0.6)
+    ]
+  end
+
+  describe "#rank" do
+    it "returns a ranked array of hashes" do
+      ranked = ranker.rank(gaps)
+      expect(ranked).to all(include(:rank, :gap))
+    end
+
+    it "assigns rank 1 to highest severity" do
+      ranked = ranker.rank(gaps)
+      expect(ranked.first[:gap].severity).to eq(0.9)
+      expect(ranked.first[:rank]).to eq(1)
+    end
+
+    it "assigns sequential ranks" do
+      ranked = ranker.rank(gaps)
+      expect(ranked.pluck(:rank)).to eq([1, 2, 3])
+    end
+
+    it "returns empty array for empty input" do
+      expect(ranker.rank([])).to eq([])
+    end
+  end
+
+  describe "#sort" do
+    it "returns gaps sorted by severity descending" do
+      sorted = ranker.sort(gaps)
+      expect(sorted.map(&:severity)).to eq([0.9, 0.6, 0.3])
+    end
+  end
+end

--- a/spec/wild/telemetry/analysis/scoring/severity_scorer_spec.rb
+++ b/spec/wild/telemetry/analysis/scoring/severity_scorer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Telemetry::Analysis::Scoring::SeverityScorer do
+  subject(:scorer) { described_class.new }
+
+  describe "#score" do
+    it "returns a Gap with adjusted severity" do
+      gap = build_gap(type: :denial, severity: 0.5)
+      scored = scorer.score(gap)
+      expect(scored).to be_a(Wild::Telemetry::Analysis::Models::Gap)
+    end
+
+    it "applies the weight for the gap type" do
+      Wild.configure { |c| c.telemetry.analysis.severity_weights = { denial: 2.0 } }
+      scorer = described_class.new
+      gap = build_gap(type: :denial, severity: 0.4)
+      scored = scorer.score(gap)
+      expect(scored.severity).to eq(0.8)
+    end
+
+    it "caps severity at 1.0 after weight application" do
+      Wild.configure { |c| c.telemetry.analysis.severity_weights = { denial: 3.0 } }
+      scorer = described_class.new
+      gap = build_gap(type: :denial, severity: 0.8)
+      scored = scorer.score(gap)
+      expect(scored.severity).to eq(1.0)
+    end
+
+    it "applies 1.0 weight when type not in config" do
+      gap = build_gap(type: :failure, severity: 0.6)
+      scored = scorer.score(gap)
+      expect(scored.severity).to eq(0.6)
+    end
+
+    it "preserves all other gap fields" do
+      gap = build_gap(type: :denial, severity: 0.5, action: "my_action", description: "desc")
+      scored = scorer.score(gap)
+      expect(scored.action).to eq("my_action")
+      expect(scored.description).to eq("desc")
+    end
+  end
+
+  describe "#score_all" do
+    it "scores each gap in the array" do
+      gaps = [build_gap(type: :denial, severity: 0.3), build_gap(type: :failure, severity: 0.6)]
+      scored = scorer.score_all(gaps)
+      expect(scored.length).to eq(2)
+      expect(scored).to all(be_a(Wild::Telemetry::Analysis::Models::Gap))
+    end
+
+    it "returns empty array when given empty array" do
+      expect(scorer.score_all([])).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Role 5 PR-10 — moves `wild-gap-miner` into `Wild::Telemetry::Analysis`. **Final of three** for the `wild-rvv.5` Telemetry epic — completes the three-gem structure move (Collector #27, Pipeline #28) **and all of Tier 2**. Tier 2 per ADR-0003.

## What landed

| Layer | Change |
|---|---|
| `lib/wild/telemetry/analysis/` | 25 source files (models, ingestion, analyzers, scoring, recommendations, report, export) |
| `lib/wild/telemetry/analysis.rb` | Loader + `.analyze` convenience method |
| `spec/wild/telemetry/analysis/` | 25 specs; `TelemetryFixtures` rewrapped; `HEADER_DATA` + flat config rewritten |
| `Wild::Configuration::Telemetry::Analysis` | Extended 1 → 9 settings (defaults verbatim from gem DEFAULTS) |
| `Wild::Telemetry::Analysis::Error` | `ParseError`, `ValidationError`, `SchemaError`, `ExportError` |
| `version.rb` + `configuration.rb` (F1) | Deleted |

## Fixture isolation fix (cross-namespace)

`build_event` collided between `Wild::Hooks::TestSupport::HookFixtures` and the telemetry `TelemetryFixtures` — both globally `config.include`d, so the last-loaded shadowed the rest and broke 6 already-merged hook_event specs. **All 7 per-namespace fixture modules are now included scoped by `file_path`** to their own spec subtree. This hardens the harness as more namespaces land.

## What is intentionally NOT in this PR

All `wild-rvv.5` children: F7 (`5.1`), F8 (`5.2`), MIN-Kleppmann (`5.3`), F6 export audit (`5.4`). Config validation + freeze machinery dropped; 8 validation/freeze adversarial specs deleted per F3.

## Local verification

| Gate | Result |
|---|---|
| `bundle exec rspec` | **2081 examples, 0 failures** (1840 prior + 249 new − 8 deleted vanity specs) |
| `bundle exec rubocop` | 351 files, **0 offenses** |
| `ruby -Ilib` smoke-load | `Wild::Telemetry::Analysis::*` resolves; `.analyze` present; `denial_threshold` → 0.2 |

CodeQL note: gap-miner's markdown exporter builds output without `escape_md`/`gsub` table-cell escaping, so it's clean of the finding class that hit #25/#26.

## Bead linkage

- **`wild-rvv.5`** (epic) — **all three sub-namespaces structurally moved**. Epic eligible to close after merge (children 5.1–5.4 are deferred behavior work tracked separately). With this, **Tier 2 is structurally complete** (Skillops ✓, Analyzers ✓, Telemetry ✓).

## Test plan

- [ ] CI green on Ruby 3.2 / 3.3 / 3.4
- [ ] CodeQL clean
- [ ] Codecov Telemetry delta ≥ 80%
- [ ] No new Packwerk boundary violations (Tier 2)

- Jeremy Longshore
intentsolutions.io