### PR TITLE
docs: reconcile build status to reality at Role 6 pause checkpoint

### DIFF
--- a/000-docs/006-OD-STAT-status.md
+++ b/000-docs/006-OD-STAT-status.md
@@ -3,8 +3,10 @@
 > Current state of the consolidation build against the 4-week plan.
 
 **Author:** Jeremy Longshore
-**Date:** 2026-05-28
-**Status:** P0 in progress
+**Date:** 2026-06-01 (Role 6 in progress; work paused for checkpoint)
+**Status:** P1 in progress — Roles 4 ✓, 5 ✓, 6 ▸ in progress, 7 ○ not started
+
+> Canonical live state: `/home/jeremy/000-projects/wild/build-orchestration/STATUS.md`. This doc mirrors its summary.
 
 ## Build plan summary
 
@@ -13,39 +15,38 @@
 
 | Phase | Span | Output | Status |
 |---|---|---|---|
-| P0 — Foundation | Week 1 days 1-3 | Empty repo with skeleton, bd initialized, 13 fixes filed as beads, governance docs + ADRs | **In progress** |
-| P1 — Library collapse | Week 1 day 4 → Week 2 day 3 | Ten old gems' `lib/` trees moved into `lib/wild/<namespace>/`, F1-F5 + F6/F7 fixes landed | Pending |
+| P0 — Foundation | Week 1 days 1-3 | Empty repo with skeleton, bd initialized, 13 fixes filed as beads, governance docs + ADRs | **✓ Complete** |
+| P1 — Library collapse | Week 1 day 4 → Week 2 day 3 | Ten old gems' `lib/` trees moved into `lib/wild/<namespace>/`, F1-F5 + F6/F7 fixes landed | **▸ In progress** (Roles 4✓ 5✓ 6▸ 7○) |
 | P2 — Rails-native shape | Week 2 days 4-7 | `Wild::Engine` mounts; `rails g wild:install`; defaulted adapters; `prompts/` + `bin/eval` | Pending |
 | P3 — Plugin layer | Week 3 | `plugins/wild/` directory with MCP servers + skill + agent + slash commands + hook | Pending |
 | P4 — Adoption proof + cutover | Week 4 | Stopwatch test passes; v0.1.0 cuts; 10 old `wild-*` repos archived with redirect READMEs; umbrella README updated | Pending |
 
-## Live progress (P0)
+## Live progress (P1)
 
 ### Done
 
-- [x] `jeremylongshore/wild` GitHub repo created (public)
-- [x] Local clone at `/home/jeremy/000-projects/wild/wild/`
-- [x] 21 governance files written (README, CHANGELOG, LICENSE, CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT, CLAUDE.md, AGENTS.md, .gitignore, .editorconfig, .gitattributes, .github/FUNDING, CODEOWNERS, PR template, issue templates × 3, dependabot, ci.yml, release.yml)
-- [x] 6-doc enterprise planning set seeded under `000-docs/`
-- [x] ADR-0001 (topology) + ADR-0002 (namespace extraction policy) committed
-- [x] Ruby gem skeleton + Wild::Engine skeleton + namespace placeholders
-- [x] Initial commit + push to GitHub
-- [x] Beads initialized; 13 council fixes filed
-- [x] Build orchestration scaffolding at `/home/jeremy/000-projects/wild/build-orchestration/`
+- [x] **P0 foundation** — repo, skeleton, governance, ADR-0001/0002, beads, orchestration scaffolding (2026-05-28)
+- [x] **Role 4 (engine architect)** — `wild-rvv.1` epic closed: one typed `Wild::Configuration` (F1), schemas-as-data substrate (F4), `Wild::Error` hierarchy (MIN-Armstrong), ADR-0003 four-tier DAG, root + 10 per-namespace `package.yml`
+- [x] **Gate 1** — engine shape passed (code moves proceeded; per-PR Fowler/Armstrong/Hickey reviews ongoing)
+- [x] **Role 5 (ruby refactor)** — all 10 namespaces moved into `lib/wild/<namespace>/` (PRs #20–#31; #31 final). 227 lib files, ~3060 specs, 0 failures, RuboCop clean
+- [x] **Role 6 (security boundary) — partial** — F2 audit-emission core (#32), detect_cycle tri-color DFS (#33), F4 corpus reconcile (#34), cut max_prerequisite_depth (#35), F2 ordering + hole (#36), F2 shape↔schema (#37)
 
-### Next up (P1)
+### Next up (Role 6 remaining → Role 7)
 
-- [ ] Role 4 (`backend-architect`): finalize engine architecture + Packwerk `package.yml` per namespace
-- [ ] Gate 1: `martin-fowler-reviewer` signs engine shape against ADR-0001 (stand-in until `dhh-reviewer` loadable)
-- [ ] Role 5 (`ruby-pro`): move ten old gems' `lib/` into `lib/wild/<namespace>/`
-- [ ] Roles 6 + 7: security boundary fixes (F2 audit-blind, `detect_cycle` false-positive) + test consolidation in parallel
+- [ ] `wild-rvv.4.1.2` — wire json-schema validator (upgrades the #37 conformance gate), closes F2 epic `wild-rvv.4.1`
+- [ ] `wild-rvv.4.2` (F6 half-published audit), `wild-rvv.5.1`/`.5.2` (F7/F8), `wild-rvv.5.3` (MIN-Kleppmann), `wild-rvv.6.2` (Hooks::Audit)
+- [ ] Role 6 follow-ups: `wild-0c3` (dark-audit ALLOW posture), `wild-28y` (inert `on_evaluation_error`)
+- [ ] Role 7 (`test-automator`): `wild-rvv.7.1` (F3 vanity-test sweep) + `wild-rvv.7.2`
+
+## Council fix tally
+
+**3 of 13 fully closed** (F1, F4, MIN-Armstrong). F2 substantially landed (validator-wiring child remains). detect_cycle + max_prerequisite_depth follow-ups also closed. Full ledger in `build-orchestration/STATUS.md`.
 
 ## Open blockers
 
 | Blocker | Owner | Mitigation |
 |---|---|---|
 | `dhh-reviewer` agent not loadable yet this session | tooling | Substitute `martin-fowler-reviewer` for P1/P2 gates; re-validate when dhh-reviewer becomes loadable |
-| Packwerk lint pass needed before code moves | Role 4 | Build into Role 4's deliverable; surface coupling violations as beads |
 
 ## Open risks (mirrored from build plan)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 - **Language**: Ruby (Rails 7.1+ engine gem)
 - **Repo**: https://github.com/jeremylongshore/wild
 - **License**: MIT
-- **Status**: v0.1.0 in flight per 4-week consolidation build plan
+- **Status**: v0.0.1 in flight (no tags yet) — P1 of the 4-week build, Role 6 in progress. v0.1.0 cuts at Role 11 after the stopwatch gate. Live state: `build-orchestration/STATUS.md`
 
 ## Canonical decisions (do NOT re-litigate)
 


### PR DESCRIPTION
Status/roadmap reconciliation during a work pause (no code change). The status docs had drifted to "P0 complete, P1 starting" (2026-05-28) while the build is actually mid-Role-6.

## Reality as of 2026-06-01
- **P0** ✓ · **Role 4** (engine) ✓ · **Role 5** (all 10 namespaces moved, PRs #20–31) ✓ · **Role 6** (security boundary) in progress (PRs #32–37).
- **Council fixes: 3 of 13 fully closed** (F1, F4, MIN-Armstrong); F2 substantially landed (validator-wiring child remains).
- No git tags; `0.0.1`. v0.1.0 cuts at Role 11.

## Changes
- `000-docs/006-OD-STAT-status.md` — P1 progress, council-fix tally, Role 6 remaining + follow-up beads.
- `CLAUDE.md` — corrected status line.

Workspace `build-orchestration/STATUS.md` (canonical live state) + the §11 status table in the `wild/` workspace CLAUDE.md updated in lockstep. Public roadmap anchor opened as #39.

Refs jeremylongshore/wild#39

- Jeremy Longshore
intentsolutions.io