### PR TITLE
fix(test): make retention and scale specs wall-clock independent

### DIFF
--- a/spec/wild/analyzers/permission/adversarial/edge_cases_spec.rb
+++ b/spec/wild/analyzers/permission/adversarial/edge_cases_spec.rb
@@ -29,8 +29,12 @@ RSpec.describe "Edge cases and adversarial inputs" do
     end
   end
 
-  describe "Large scale performance" do
-    it "analyzes 500 capabilities and 200 grants in under 5 seconds" do
+  describe "Large scale shape" do
+    # Formerly asserted `elapsed < 5.0`; a wall-clock bound fails under CI load
+    # (about 3s on an idle box) and proves nothing about correctness. This is a
+    # shape test now: 500 capabilities x 200 wildcard grants must still produce
+    # a well-formed report. The ~3s cost is a review-wave P2 input.
+    it "analyzes 500 capabilities and 200 grants into a well-formed report" do
       caps = (1..500).map do |i|
         Wild::Analyzers::Permission::Models::Capability.new(name: "cap.group#{i % 10}.item#{i}", risk_level: "low")
       end
@@ -41,10 +45,10 @@ RSpec.describe "Edge cases and adversarial inputs" do
           expires_at: "2099-01-01"
         )
       end
-      start = Time.now.utc
-      Wild::Analyzers::Permission::Report::Builder.new(caps, grants).build
-      elapsed = Time.now.utc - start
-      expect(elapsed).to be < 5.0
+      report = Wild::Analyzers::Permission::Report::Builder.new(caps, grants).build
+      expect(report).to be_a(Wild::Analyzers::Permission::Models::AuditReport)
+      expect(report.findings).to all(be_a(Wild::Analyzers::Permission::Models::Finding))
+      expect(report.coverage_reports.size).to eq(grants.size)
     end
   end
 

--- a/spec/wild/telemetry/collector/store/retention_manager_spec.rb
+++ b/spec/wild/telemetry/collector/store/retention_manager_spec.rb
@@ -11,27 +11,32 @@ RSpec.describe Wild::Telemetry::Collector::Store::RetentionManager do
   let(:store_path) { File.join(tmpdir, "events.jsonl") }
   let(:store) { Wild::Telemetry::Collector::Store::JsonLinesStore.new(path: store_path) }
 
-  # old_envelope has a received_at that is ~108 days before 2026-03-19,
-  # well outside a 90-day retention window.
+  # Timestamps are computed relative to now so the fixtures never age past the
+  # 90-day retention window (a hardcoded 2026-03-19 "recent" fixture expired on
+  # 2026-06-17 and turned 6 examples red). old_envelope sits 120 days back,
+  # well outside the window; new_envelope sits 1 day back, well inside it.
+  let(:old_received_at) { (Time.now.utc - (120 * 86_400)).iso8601(3) }
+  let(:new_received_at) { (Time.now.utc - 86_400).iso8601(3) }
+
   let(:old_envelope) do
     Wild::Telemetry::Collector::Schema::EventEnvelope.new(
       event_type: "action.completed",
-      timestamp: "2025-12-01T00:00:00.000Z",
+      timestamp: old_received_at,
       caller_id: "test",
       action: "old_action",
       outcome: "success",
-      received_at: "2025-12-01T00:00:00.000Z"
+      received_at: old_received_at
     )
   end
 
   let(:new_envelope) do
     Wild::Telemetry::Collector::Schema::EventEnvelope.new(
       event_type: "action.completed",
-      timestamp: "2026-03-19T00:00:00.000Z",
+      timestamp: new_received_at,
       caller_id: "test",
       action: "new_action",
       outcome: "success",
-      received_at: "2026-03-19T00:00:00.000Z"
+      received_at: new_received_at
     )
   end
 


### PR DESCRIPTION
## What
- `spec/wild/telemetry/collector/store/retention_manager_spec.rb`: old/new fixture timestamps computed relative to `Time.now.utc` (120 days back / 1 day back), the pattern the file already used for `fresh_envelope`.
- `spec/wild/analyzers/permission/adversarial/edge_cases_spec.rb`: the `elapsed < 5.0` timing assertion is gone; the example is now a shape test (500 caps × 200 wildcard grants → an `AuditReport` of `Finding`s with one `CoverageReport` per grant).

## Why + decision rationale
The hardcoded `2026-03-19` "recent" fixture aged past the 90-day retention window on 2026-06-17, so `purge_expired` removed both fixtures (6 failures). The timing bound fails under CI load (~3s on an idle box) and proves nothing about correctness. Chose **relative timestamps over timecop/clock injection** because the file already used that pattern and the code under test reads `Time.now` once. (The workspace CLAUDE.md had called the second failure order-dependent; it is not. Corrected there.)

## Layer(s) touched
Specs only. No `lib/` change.

## Verification & evidence
Local `bundle exec rspec` on seeds `41803`, `1`, `20260825`: **3076 examples, 0 failures** each; line coverage 98.28% / 98.28% / 98.24%. RuboCop clean on both files. CI on this PR (stacked on #51 so Lint resolves the same RuboCop) is the first fully green run since 2026-06-04.

## Risk assessment
None to runtime. The retention test still exercises both sides of the window.

## Operational impact
None.

## Follow-up & deferred
- `minimum_coverage_by_file 75` stays disabled: 5 files are below it (`admin_tools/executor/adapters/{job,flag,cache}_adapter.rb` 62–65%, `telemetry/collector/store/base.rb` 65%, `admin_tools/configuration.rb` 72%). Recorded as review-wave input (`facts.json`), not enabled red.
- The ~3s cost of the 500×200 case is a P2 candidate for lane L05 (permission analyzer).

## Governance links
Beads: *Compute the retention spec fixtures relative to now so they stop aging past the window*; *Drop the wall-clock bound from the permission scale spec and keep it as a shape test*. Stacked on #51; retargets to `main` when #51 merges.

Refs #48