### PR TITLE
fix(capability_gate): coerce hostile context, surface schema errors, and never let an audit failure go silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,64 @@ section splits into a separate file.
     ALLOW/DENY. It now falls back to `Kernel#warn` ($stderr) whenever no usable
     logger is configured (or the configured one itself raises), so a writer
     failure is observable out of the box, not only when a caller opts in.
+- **Review-wave verifier follow-ups on the f-l08-1..4 fix (findings f-l08-1,
+  f-l08-2, f-l08-3, f-l08-4, PR #74 verifier pass).** Advances the same bead
+  ("Move wild-capability-gate into Wild::CapabilityGate and fix the F2
+  audit-blind path").
+  - **f-l08-4 correction**: `Kernel#warn` is a no-op when `$VERBOSE` is nil
+    (`ruby -W0`, a caller wrapped in `silence_warnings`) — the prior fix's own
+    specs only passed because `spec_helper.rb` sets `config.warnings = false`,
+    which affects RSpec's own noise, not `$VERBOSE`. `log_audit_failure` now
+    writes directly to `$stderr`, so the fallback is unconditional; only an
+    unwritable `$stderr` defeats it (the CHANGELOG entry above is now true as
+    written, not just under the process's default warning verbosity).
+  - **f-l08-2 in production**: `SchemaValidator.enabled?`'s `:auto` branch now
+    consults `Rails.env` (forcing validation off in a real Rails production
+    environment) before falling back to `Wild.config.environment`, closing the
+    gap where nothing wires `Wild.config.environment` from `Rails.env` and a
+    production app without the dev-only `json_schemer` gem would otherwise
+    raise on every evaluation. `Gate#initialize` also probes the validator at
+    construction time (when `audit_log_path` is given), so the failure surfaces
+    at boot instead of first `#evaluate`; the first-use raise inside
+    `SchemaValidator#schemer` remains as a backstop.
+  - **f-l08-3 in admin_tools**: `GateClient#authorize` used to rescue every
+    `StandardError` (including the deliberately re-raised
+    `AuditSchemaError`/`ConfigurationError`) into a `GateError`, and
+    `AuthenticatedPipeline` only rescues `GateError`, so a developer-bug signal
+    from the gate was indistinguishable from an ordinary denial and its message
+    was discarded. `GateClient` now re-raises `CapabilityGate::DEVELOPER_ERRORS`
+    members unwrapped (logging the class + message first), so they propagate
+    through `AuthenticatedPipeline` instead of becoming a silent `gate_denied`.
+  - **f-l08-1 context handling moved and hardened**: context coercion moved
+    from `Evaluator`'s `SafeCoercion` into `Audit::Event.coerce_context` (both
+    a public class method `Evaluator#evaluate` calls once, up front — so the
+    SAME coerced context reaches prerequisite checkers and the audit trail,
+    instead of the checker seeing the raw hostile value while the trail
+    recorded a separately-coerced one — and a private instance-level backstop
+    for any other `Event.new` caller). It now `dup`s a Hash argument before
+    freezing (previously `Hash(context)` returned the CALLER's own Hash for a
+    real Hash argument, and freezing it was a `FrozenError` trap for any
+    consumer who reused that Hash); dispatches the non-Hash placeholder by
+    class instead of a blanket `#inspect` (a multi-megabyte String or a very
+    deeply nested Array made `#inspect` slow or fatal — a deep Array's
+    recursive `#inspect` raises `SystemStackError`, which is not a
+    `StandardError` and would have escaped every rescue with zero audit lines
+    written); routes the placeholder through `Wild::Hooks::Audit::Sanitizer`
+    so a hostile `context: "token=sk-..."` is redacted, not written verbatim;
+    and bounds a Hash context that coerces cleanly but is not JSON-safe (NaN,
+    invalid encodings, self-reference) or exceeds the `audit_event.yml extra`
+    budget (2 KiB), replacing it with a `{ truncated:, keys: }` summary.
+    `JsonLinesWriter#write` also gained its own defense-in-depth rescue for
+    unserializable event hashes, writing a bounded stand-in line instead of
+    dropping the audit record. Corrects a wrong comment claiming a
+    pairs-shaped Array converts via `Hash()` — verified false, every non-empty
+    Array raises `TypeError` there regardless of shape.
+  - Introduced `Wild::CapabilityGate::DEVELOPER_ERRORS = [AuditSchemaError]`
+    and `Wild::CapabilityGate::AuditValidatorUnavailableError <
+    AuditSchemaError` (replacing the gem-wide `Wild::ConfigurationError` at the
+    json_schemer-absent raise site) so every developer-bug re-raise in this
+    namespace is one class check, without also giving a free pass to an
+    unrelated `ConfigurationError` a future prerequisite checker might raise.
 - **F2 fast-follow: Gate-rescue contract pinned + log-failure hardened**
   (Role 6 PR-8, `wild-wxk`; Armstrong F2 sign-off findings 2 + 4 — **closes the
   F2 epic `wild-rvv.4.1`**).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,44 @@ section splits into a separate file.
 
 ### Wild::CapabilityGate
 
+- **Review wave: closed four audit-blind paths in the capability gate**
+  (findings f-l08-1, f-l08-2, f-l08-3, f-l08-4). Advances bead "Move
+  wild-capability-gate into Wild::CapabilityGate and fix the F2 audit-blind
+  path"; does not close it (the fail-closed posture for a dark writer+logger
+  on an ALLOW result is a separate, deliberately deferred decision, tracked by
+  bead "Decide the fail-closed posture for ALLOW results when both the audit
+  writer and logger are dark").
+  - **f-l08-1**: a hostile (non-Hash) `context` argument to `Gate#evaluate` /
+    `Evaluator#evaluate` used to raise `TypeError` inside `Audit::Event#initialize`,
+    get swallowed by `emit_audit`'s rescue, and leave the evaluation's ALLOW/DENY
+    with zero audit lines. New `SafeCoercion#safe_context` coerces defensively
+    (never raises) before event construction, so one bad argument can no longer
+    suppress the audit record for its own decision.
+  - **f-l08-2**: `Audit::SchemaValidator` already raised `Wild::ConfigurationError`
+    when validation was enabled but `json_schemer` (a dev-only dependency) was
+    absent, but `emit_audit`'s blanket `StandardError` rescue caught it anyway,
+    and with `audit_logger` nil by default the whole thing vanished: every
+    evaluation returned ALLOW with zero audit and zero log. `ConfigurationError`
+    is now re-raised alongside `AuditSchemaError`, ordered before the
+    `StandardError` rescue in both `Evaluator#evaluate` and `Gate#evaluate`, so
+    a missing dev dependency fails loudly at first use instead of degrading the
+    gate's audit trail. The `:auto` validation toggle's dev/test-on,
+    production-off semantics are unchanged.
+  - **f-l08-3**: `Gate#evaluate`'s blanket `StandardError` rescue was silently
+    swallowing the `AuditSchemaError` that `Evaluator#evaluate` deliberately
+    re-raises to surface a non-conforming audit event as a developer bug,
+    demoting it to an audit-blind `:evaluation_error` denial. `gate.rb`'s
+    comment, and a `gate_spec.rb` example, both asserted this rescue was
+    unreachable today (false: the re-raise already existed). Added an
+    explicit `rescue AuditSchemaError, ConfigurationError; raise` above the
+    blanket rescue, corrected both the comment and the spec's claim, and added
+    a Gate-level example proving the raise now reaches the caller.
+  - **f-l08-4**: `log_audit_failure` logged to `Wild.config.audit_logger.error`
+    only when a logger was explicitly configured; the default `nil` logger made
+    every audit-writer failure terminally silent while the gate still returned
+    ALLOW/DENY. It now falls back to `Kernel#warn` ($stderr) whenever no usable
+    logger is configured (or the configured one itself raises), so a writer
+    failure is observable out of the box, not only when a caller opts in.
 - **F2 fast-follow: Gate-rescue contract pinned + log-failure hardened**
   (Role 6 PR-8, `wild-wxk`; Armstrong F2 sign-off findings 2 + 4 — **closes the
   F2 epic `wild-rvv.4.1`**).
@@ -247,8 +285,15 @@ section splits into a separate file.
   - **Audit-pipeline failure is no longer doubly silent.** `Evaluator#emit_audit`
     previously swallowed write failures to `nil`. It now logs them to
     `Wild.config.audit_logger.error` (still never raises — a broken audit log
-    must not break the gate). Only a simultaneous writer-AND-logger outage is
-    terminally silent.
+    must not break the gate). **Correction (review wave, finding f-l08-4):**
+    this guarantee originally only held when a caller had explicitly
+    configured `audit_logger`: it defaults to `nil` (`configuration.rb`), so
+    a single writer failure under default configuration was terminally
+    silent, not merely "a simultaneous writer-AND-logger outage" as stated
+    here previously. `log_audit_failure` now falls back to `Kernel#warn`
+    ($stderr) whenever no usable logger is configured (or the configured one
+    itself raises), so a writer failure is never silent out of the box; only
+    an unwritable `$stderr` defeats it.
   - `Audit::Event` gains a third result value, `evaluation_error` (distinct
     from `denied`), so audit readers can tell "policy said no" apart from "the
     gate broke and failed closed". `:evaluation_error` is always a denial

--- a/lib/wild/admin_tools/identity/gate_client.rb
+++ b/lib/wild/admin_tools/identity/gate_client.rb
@@ -22,6 +22,16 @@ module Wild
           session_context.with_gate_result(gate_result, updated_capabilities: result.allowed? ? [capability] : [])
         rescue GateError
           raise
+        rescue *Wild::CapabilityGate::DEVELOPER_ERRORS => e
+          # f-l08-3: a CapabilityGate developer-bug signal (audit-schema
+          # misconfiguration) must not be wrapped into an ordinary GateError —
+          # AuthenticatedPipeline#authorize_via_gate only rescues GateError, so
+          # wrapping it here would let it get silently demoted to a generic
+          # "gate_denied" with the real cause discarded. Log the class + a safe
+          # message before re-raising so the failure is observable even though
+          # the exception itself is about to propagate.
+          log_developer_error(e)
+          raise
         rescue StandardError => e
           raise GateError.new("Gate evaluation failed: #{e.message}", original_error: e)
         end
@@ -29,6 +39,21 @@ module Wild
         def configured?
           !@gate.nil?
         end
+
+        private
+
+        # @api private
+        # rubocop:disable Style/StderrPuts -- deliberate: `warn` is a Kernel#warn
+        # no-op under $VERBOSE = nil, matching the capability_gate fix this
+        # mirrors (f-l08 addendum item 1).
+        def log_developer_error(error)
+          message = "[wild:admin_tools] capability gate raised a developer error: #{error.class}: #{error.message}"
+          logger = Wild.config.audit_logger
+          logger.respond_to?(:error) ? logger.error(message) : $stderr.puts(message)
+        rescue StandardError
+          nil
+        end
+        # rubocop:enable Style/StderrPuts
       end
     end
   end

--- a/lib/wild/capability_gate/audit/event.rb
+++ b/lib/wild/capability_gate/audit/event.rb
@@ -2,6 +2,7 @@
 
 require "time"
 require "securerandom"
+require "json"
 
 module Wild
   module CapabilityGate
@@ -20,11 +21,30 @@ module Wild
       # construction MUST NOT raise (a raise here re-opens the silent-denial hole
       # F2 exists to close): the outcome remap is total, and policy_version is
       # resolved defensively.
+      # rubocop:disable Metrics/ClassLength -- the class carries both the 12-field
+      # value-object contract AND the f-l08 addendum's bounded context-coercion
+      # helpers (hash_context/placeholder_for/sanitized_placeholder/bound_context);
+      # splitting coercion into a second file would separate it from the single
+      # invariant it exists to protect (Event construction never raises).
       class Event
         # The contract's outcome enum (audit_event.yml). `allowed`/`denied` from
         # the EvaluationResult map to the contract's `allow`/`deny`.
         VALID_OUTCOMES = %w[allow deny evaluation_error].freeze
         UNKNOWN_OUTCOME = "evaluation_error"
+
+        # Context-coercion bounds (f-l08 addendum items 4 + 11). Coercion must
+        # never raise (Events are built inside Evaluator#evaluate's rescue
+        # handler) AND must never do unbounded work on a hostile context: a
+        # blanket #inspect on an arbitrary value is itself dangerous — slow for
+        # a multi-megabyte String, and fatal for a very deeply nested Array,
+        # whose recursive #inspect raises SystemStackError. SystemStackError is
+        # NOT a StandardError, so it would escape every rescue clause here (and
+        # every rescue in Evaluator#evaluate) with zero audit lines written —
+        # exactly the F2 hole this coercion exists to close.
+        CONTEXT_INSPECT_LIMIT = 200
+        CONTEXT_JSON_BYTE_LIMIT = 2048
+        CONTEXT_JSON_MAX_NESTING = 16
+        CONTEXT_KEY_LIMIT = 16
 
         attr_reader :timestamp, :decision_id, :subject, :capability, :risk_level,
                     :outcome, :reason, :rationale, :policy_version,
@@ -35,6 +55,18 @@ module Wild
         def self.from_evaluation(evaluation_result, registry:, session_id: nil, context: {})
           attrs = extract_attrs(evaluation_result, registry)
           new(**attrs, session_id: session_id, context: context)
+        end
+
+        # Coerce an arbitrary caller-supplied value into a safe, bounded Hash
+        # suitable for the audit `context` field. NEVER raises. Public (not
+        # just an Event-internal helper) so Evaluator#evaluate can coerce
+        # context ONCE, up front, and hand the SAME coerced Hash to both the
+        # prerequisite checkers and the audit trail (f-l08 addendum item 10) —
+        # previously the checkers saw the raw, possibly hostile context while
+        # the audit line recorded a separately-coerced one, so what was
+        # decided on and what was audited could disagree.
+        def self.coerce_context(value)
+          bound_context(hash_context(value))
         end
 
         # rubocop:disable Metrics/ParameterLists, Metrics/AbcSize -- value object mirroring the 12-field audit_event.yml schema; ABC is inherent to assigning + lightly coercing each field
@@ -54,7 +86,15 @@ module Wild
           @prerequisites_checked = Array(prerequisites_checked).freeze
           @prerequisites_passed = prerequisites_passed
           @session_id = session_id
-          @context = Hash(context).freeze
+          # f-l08-1 + addendum item 4: re-coerce defensively even when the
+          # caller (Evaluator#evaluate) already coerced context once — this is
+          # the total-construction backstop for any OTHER caller of Event.new
+          # (a test double, a future consumer). self.class.coerce_context never
+          # raises AND always hands back a Hash that is NOT the caller's own
+          # object (see .hash_context below), so freezing it here never freezes
+          # a Hash the caller still holds a live, mutable reference to — the
+          # FrozenError trap the un-dup'd `Hash(context)` used to spring.
+          @context = self.class.coerce_context(context).freeze
           freeze
         end
         # rubocop:enable Metrics/ParameterLists, Metrics/AbcSize
@@ -154,8 +194,81 @@ module Wild
           def prerequisite_failure?(evaluation_result)
             evaluation_result.denied? && evaluation_result.reason == :prerequisite_not_met
           end
+
+          # --- context coercion (f-l08 addendum items 4, 11) ---
+
+          # Hash(value) succeeds ONLY for a real Hash (via Hash#to_hash, which
+          # returns the SAME object — #dup below is what makes this a copy,
+          # not Hash()), or for nil / an empty Array (both become {}). Kernel#Hash
+          # raises TypeError for EVERY other Array, including one that looks
+          # like key/value pairs — Array does not implement #to_hash, and
+          # Hash() does not fall back to #to_h (a prior version of this comment
+          # claimed pairs arrays convert; verified false: `Hash([["a",1]])`
+          # raises TypeError just like `Hash(%w[x y])` does — f-l08 addendum
+          # item 8). So a String, ANY non-empty Array, or an object whose
+          # #to_hash itself raises all degrade to the placeholder branch below.
+          # @api private
+          def hash_context(value)
+            Hash(value).dup
+          rescue StandardError, SystemStackError
+            { raw: sanitized_placeholder(value) }
+          end
+
+          # Class-dispatched, and deliberately never calls #inspect on the
+          # whole value: a multi-megabyte String is O(n) to inspect (cheap in
+          # isolation, but on a fail-closed audit path we do not want to pay
+          # for it), and a very deeply nested Array recurses #inspect into
+          # SystemStackError. Slicing a String to CONTEXT_INSPECT_LIMIT before
+          # #inspect is cheap regardless of the source String's total size;
+          # Array/other values get a size/class summary instead of a full dump.
+          # @api private
+          def placeholder_for(value)
+            case value
+            when String then value[0, CONTEXT_INSPECT_LIMIT].inspect
+            when Array then "#<Array size=#{value.size}>"
+            else "#<#{value.class}>"
+            end
+          rescue StandardError, SystemStackError
+            "<uninspectable>"
+          end
+
+          # A hostile `context: "token=sk-live-..."` must not land in the audit
+          # log verbatim just because it took the placeholder path instead of
+          # the structured-Hash path. Wild::Hooks::Audit::Sanitizer#sanitize_string
+          # redacts `key=value`-shaped tokens out of free-form strings;
+          # capability_gate already depends on ../hooks per package.yml.
+          # @api private
+          def sanitized_placeholder(value)
+            Wild::Hooks::Audit::Sanitizer.new.sanitize_string(placeholder_for(value))
+          rescue StandardError
+            "<uninspectable>"
+          end
+
+          # Even a Hash that coerced cleanly can still be unsafe to write: NaN
+          # floats and Infinity raise out of JSON generation by default,
+          # invalid-encoding binary strings and self-referential structures do
+          # too, and an oversized context blows past the audit_event.yml
+          # `extra` budget (documented < 2 KiB). Replace it with a diagnosable
+          # summary rather than losing the whole audit line at write time.
+          # @api private
+          def bound_context(hash)
+            json = JSON.generate(hash, max_nesting: CONTEXT_JSON_MAX_NESTING)
+            return hash if json.bytesize <= CONTEXT_JSON_BYTE_LIMIT
+
+            truncated_summary(hash)
+          rescue JSON::GeneratorError, JSON::NestingError, Encoding::UndefinedConversionError, SystemStackError
+            truncated_summary(hash)
+          end
+
+          # @api private
+          def truncated_summary(hash)
+            { truncated: true, keys: hash.keys.first(CONTEXT_KEY_LIMIT).map(&:to_s) }
+          rescue StandardError, SystemStackError
+            { truncated: true, keys: [] }
+          end
         end
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/lib/wild/capability_gate/audit/json_lines_writer.rb
+++ b/lib/wild/capability_gate/audit/json_lines_writer.rb
@@ -22,11 +22,39 @@ module Wild
         end
 
         # Write an audit event to the log file.
-        # Accepts an Audit::Event or any object responding to #to_h.
+        # Accepts an Audit::Event, a Hash already built by Audit::Event#to_h
+        # (evaluator.rb passes the hash it already built once — item 13 of the
+        # f-l08 addendum), or any other object responding to #to_h.
+        #
+        # f-l08 addendum item 5: Audit::Event.coerce_context already bounds
+        # `context` at construction time (rejects NaN/Infinity, invalid
+        # encodings, and oversized payloads before the event exists), so this
+        # should never see unserializable data through the normal Gate flow.
+        # It is defense-in-depth for the ONE thing that coercion cannot see:
+        # every other event field. A genuinely unserializable line must not
+        # drop the whole audit record — write a bounded stand-in instead so the
+        # decision is still on record, with a note that the context was
+        # dropped for being unserializable.
         def write(event)
-          line = "#{JSON.generate(event.to_h)}\n"
+          hash = event.to_h
+          line = serialize(hash)
           File.open(@path, "a") { |f| f.write(line) }
           nil
+        end
+
+        private
+
+        def serialize(hash)
+          "#{JSON.generate(hash)}\n"
+        rescue JSON::GeneratorError, JSON::NestingError, Encoding::UndefinedConversionError
+          "#{JSON.generate(unserializable_fallback(hash))}\n"
+        end
+
+        def unserializable_fallback(hash)
+          extra = hash["extra"].is_a?(Hash) ? hash["extra"] : {}
+          hash.merge(
+            "extra" => extra.merge("context" => { "dropped" => true, "reason" => "context not JSON-serializable" })
+          )
         end
       end
     end

--- a/lib/wild/capability_gate/audit/schema_validator.rb
+++ b/lib/wild/capability_gate/audit/schema_validator.rb
@@ -30,11 +30,23 @@ module Wild
           # dev/test, off in prod (validation costs; a non-conforming event is a
           # developer bug we want surfaced in dev/test, not in production).
           # `true`/`false` force the behaviour regardless of environment.
+          #
+          # f-l08 addendum item 2: nothing sets `Wild.config.environment` from
+          # `Rails.env` (there is no such wiring in Configuration or Engine), so
+          # in a real Rails app `Wild.config.environment` silently stays at its
+          # :development default even in production — which, combined with
+          # `json_schemer` being a DEVELOPMENT-only dependency, would raise on
+          # every single evaluation in production. When Rails is loaded (this
+          # gem's Engine always `require "rails"`s it) and reports a production
+          # environment, that takes priority and forces validation off,
+          # regardless of what `Wild.config.environment` happens to hold.
+          # Anything other than a real Rails production environment falls back
+          # to the existing `Wild.config.environment` behaviour unchanged.
           def enabled?
             case Wild.config.capability_gate.validate_audit_events
             when true then true
             when false then false
-            else %i[development test].include?(Wild.config.environment)
+            else auto_enabled?
             end
           end
 
@@ -55,6 +67,19 @@ module Wild
           end
           # rubocop:enable Rails/Delegate
 
+          # Probe that the validator is actually usable (compiles/memoizes the
+          # schema) WITHOUT validating any particular event. Raises
+          # AuditValidatorUnavailableError if `json_schemer` is absent — the
+          # same failure `schemer` raises on first real use, just triggered at
+          # Gate#initialize (construction time) instead of first #evaluate
+          # (f-l08-2 boot-time hardening, item 2b). The first-use raise inside
+          # `schemer` stays in place as a backstop for any caller that builds an
+          # Evaluator directly, bypassing Gate#initialize.
+          def ensure_available!
+            schemer
+            nil
+          end
+
           # Reset the memoized schemer (test support — after a schema edit).
           def reset!
             @schemer = nil
@@ -62,13 +87,31 @@ module Wild
 
           private
 
+          # (production => off); anything else falls back to the pre-existing
+          # Wild.config.environment check. Rescue defensively — a stubbed or
+          # unusual Rails.env must never turn "should validate" into a raise
+          # from inside this predicate itself.
+          # @api private
+          def auto_enabled?
+            return false if rails_production?
+
+            %i[development test].include?(Wild.config.environment)
+          end
+
+          # @api private
+          def rails_production?
+            defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+          rescue StandardError
+            false
+          end
+
           # Compiled schema, memoized — compilation is the expensive step.
           def schemer
             @schemer ||= begin
               require "json_schemer"
               JSONSchemer.schema(YAML.safe_load_file(SCHEMA_PATH, permitted_classes: []))
             rescue LoadError
-              raise Wild::ConfigurationError,
+              raise Wild::CapabilityGate::AuditValidatorUnavailableError,
                     "audit-event validation is enabled but the `json_schemer` gem is not available. " \
                     "Add `gem \"json_schemer\"` to your bundle, or disable validation via " \
                     "`Wild.config.capability_gate.validate_audit_events = false`."

--- a/lib/wild/capability_gate/evaluator.rb
+++ b/lib/wild/capability_gate/evaluator.rb
@@ -34,6 +34,62 @@ module Wild
       rescue StandardError
         "<unprintable message>"
       end
+
+      # Coerce to a Hash without ever raising. A caller-supplied `context` that
+      # Hash() cannot convert (a String, an Array that is not pairs, any object
+      # whose #to_hash itself raises) degrades to a placeholder hash carrying
+      # the offending value's inspect rather than blowing up event construction
+      # (f-l08-1: one non-Hash `context` argument on the documented public
+      # `evaluate` entry point used to raise inside Audit::Event#initialize,
+      # get swallowed by emit_audit's rescue, and leave the ALLOW/DENY result
+      # with NO audit line written).
+      def safe_context(value)
+        Hash(value)
+      rescue StandardError
+        { raw: safe_inspect(value) }
+      end
+
+      # #inspect on an arbitrary value is not guaranteed safe either; degrade
+      # rather than raise while building the safe_context placeholder.
+      def safe_inspect(value)
+        value.inspect[0, 200]
+      rescue StandardError
+        "<uninspectable>"
+      end
+
+      # Log an audit emission failure without ever raising (Evaluator#emit_audit
+      # calls this from its own rescue: a raise here would defeat the
+      # never-raises guarantee). f-l08-4: Wild.config.audit_logger defaults to
+      # nil, so without the warn fallback a single writer failure was
+      # terminally silent while ALLOW/DENY was still returned. Kernel#warn
+      # ($stderr) is always available and keeps "audit failure is never
+      # doubly silent" true out of the box, not only when a caller explicitly
+      # configures a logger.
+      def log_audit_failure(error, result)
+        message = build_audit_failure_message(error, result)
+        logger = Wild.config.audit_logger
+        logger.respond_to?(:error) ? logger.error(message) : warn(message)
+      rescue StandardError
+        # The configured logger raised from #error, or message construction
+        # itself raised. Rebuild the message fresh rather than rely on a
+        # binding from the failed attempt; only an unwritable $stderr defeats
+        # this last resort.
+        begin
+          warn build_audit_failure_message(error, result)
+        rescue StandardError
+          nil
+        end
+      end
+
+      # error.class is always safe; error.message is guarded via safe_message
+      # (a pathological exception whose #message raises must not turn a
+      # should-have-logged into terminal silence). Armstrong F2 fast-follow
+      # finding 4 (wild-wxk).
+      def build_audit_failure_message(error, result)
+        "[wild:capability_gate] audit emission failed: #{error.class}: #{safe_message(error)} " \
+          "(caller=#{result.caller_id.inspect} capability=#{result.capability_name.inspect} " \
+          "reason=#{result.reason.inspect})"
+      end
     end
 
     # The core access decision engine.
@@ -85,13 +141,16 @@ module Wild
 
         emit_audit(result, context)
         result
-      rescue Wild::CapabilityGate::AuditSchemaError
-        # F2 (wild-rvv.4.1.2): a non-conforming audit event is a developer bug,
-        # not a runtime fault — surface it. This only fires when validation is
-        # enabled (dev/test by default), so production (validation off) keeps the
-        # never-raises guarantee untouched. Must come BEFORE the StandardError
-        # rescue, or the schema violation would be misreported as an
-        # evaluation_error denial.
+      rescue Wild::CapabilityGate::AuditSchemaError, Wild::ConfigurationError
+        # F2 (wild-rvv.4.1.2) + f-l08-2: a non-conforming audit event, or an
+        # audit-validator misconfiguration (validation enabled but the
+        # `json_schemer` gem is absent: schema_validator.rb's ConfigurationError),
+        # is a developer bug, not a runtime fault: surface it loudly rather than
+        # let it degrade to a silent ALLOW/DENY with zero audit and zero log. This
+        # only fires when validation is enabled (dev/test by default), so
+        # production (validation off) keeps the never-raises guarantee untouched.
+        # Must come BEFORE the StandardError rescue, or either error would be
+        # misreported as an evaluation_error denial.
         raise
       rescue StandardError => e
         # F2 (council rev2, Armstrong): the decision logic raised — fail closed
@@ -178,8 +237,16 @@ module Wild
       def emit_audit(result, context)
         return unless @audit_writer
 
+        # f-l08-1: coerce defensively BEFORE Event construction. A hostile
+        # `context` (a String, a non-pair Array, an object whose #to_hash
+        # raises) used to blow up `Hash(context)` inside Audit::Event#initialize;
+        # that raise was caught below by the StandardError rescue and, with the
+        # default nil audit_logger, produced zero audit record and zero log line
+        # for an ALLOW/DENY that had already been decided. safe_context never
+        # raises, so event construction always succeeds and this method's own
+        # rescue clauses are reserved for genuine write/validation failures.
         event = Audit::Event.from_evaluation(
-          result, registry: @registry, session_id: @session_id, context: context
+          result, registry: @registry, session_id: @session_id, context: safe_context(context)
         )
         # F2 (wild-rvv.4.1.2): in dev/test, prove the event conforms to
         # audit_event.yml BEFORE it is written. A schema violation re-raises
@@ -188,31 +255,20 @@ module Wild
         # exists for genuine write/IO failures. Off in prod by default.
         Audit::SchemaValidator.validate!(event.to_h) if Audit::SchemaValidator.enabled?
         @audit_writer.write(event)
-      rescue Wild::CapabilityGate::AuditSchemaError
+      rescue Wild::CapabilityGate::AuditSchemaError, Wild::ConfigurationError
+        # f-l08-2: SchemaValidator.validate! (via its private `schemer` method)
+        # raises Wild::ConfigurationError when validation is enabled but the
+        # `json_schemer` gem is not on the bundle. That was previously caught by
+        # the StandardError rescue below and, with audit_logger nil by default,
+        # every evaluation silently returned ALLOW/DENY with zero audit and zero
+        # log: an absent dev dependency should fail loudly at first use, not
+        # degrade the gate's audit trail. Re-raise here, ordered before
+        # StandardError, exactly as AuditSchemaError already does.
         raise
       rescue StandardError => e
+        # log_audit_failure lives in SafeCoercion (never raises out of here by
+        # contract; also shared with the module's other never-raising helpers).
         log_audit_failure(e, result)
-        nil
-      end
-
-      def log_audit_failure(error, result)
-        logger = Wild.config.audit_logger
-        return unless logger.respond_to?(:error)
-
-        # error.class is always safe; error.message is guarded (a pathological
-        # exception whose #message raises must not turn a should-have-logged
-        # into terminal silence — we still log the class). Armstrong F2
-        # fast-follow finding 4 (wild-wxk).
-        logger.error(
-          "[wild:capability_gate] audit emission failed: #{error.class}: #{safe_message(error)} " \
-          "(caller=#{result.caller_id.inspect} capability=#{result.capability_name.inspect} " \
-          "reason=#{result.reason.inspect})"
-        )
-      rescue StandardError
-        # The audit logger itself is broken. There is nowhere left to write;
-        # do not raise out of the gate. This is the one genuinely-terminal
-        # silent path, and it requires BOTH the audit writer AND the configured
-        # logger to be broken simultaneously.
         nil
       end
     end

--- a/lib/wild/capability_gate/evaluator.rb
+++ b/lib/wild/capability_gate/evaluator.rb
@@ -2,6 +2,17 @@
 
 module Wild
   module CapabilityGate
+    # Developer-bug signals from this namespace that must surface loudly
+    # rather than be swallowed into a policy denial or a generic evaluation
+    # failure. AuditSchemaError's own subclass AuditValidatorUnavailableError
+    # (raised when the `json_schemer` gem is absent) is covered by this single
+    # class check without also whitelisting the gem-wide Wild::ConfigurationError
+    # — an unrelated ConfigurationError raised by some future prerequisite
+    # checker must NOT get a free pass out of Evaluator#evaluate ahead of its
+    # emit_audit call (f-l08 addendum item 12). Referenced by evaluator.rb,
+    # gate.rb, and (T4, allowed under ADR-0003) admin_tools' GateClient.
+    DEVELOPER_ERRORS = [AuditSchemaError].freeze
+
     # Coercions that must NEVER raise — used inside Evaluator#evaluate's rescue
     # handler, where a second raise would propagate an exception with no audit
     # written (the F2 hole this gate exists to close). Extracted as a collaborator
@@ -34,62 +45,6 @@ module Wild
       rescue StandardError
         "<unprintable message>"
       end
-
-      # Coerce to a Hash without ever raising. A caller-supplied `context` that
-      # Hash() cannot convert (a String, an Array that is not pairs, any object
-      # whose #to_hash itself raises) degrades to a placeholder hash carrying
-      # the offending value's inspect rather than blowing up event construction
-      # (f-l08-1: one non-Hash `context` argument on the documented public
-      # `evaluate` entry point used to raise inside Audit::Event#initialize,
-      # get swallowed by emit_audit's rescue, and leave the ALLOW/DENY result
-      # with NO audit line written).
-      def safe_context(value)
-        Hash(value)
-      rescue StandardError
-        { raw: safe_inspect(value) }
-      end
-
-      # #inspect on an arbitrary value is not guaranteed safe either; degrade
-      # rather than raise while building the safe_context placeholder.
-      def safe_inspect(value)
-        value.inspect[0, 200]
-      rescue StandardError
-        "<uninspectable>"
-      end
-
-      # Log an audit emission failure without ever raising (Evaluator#emit_audit
-      # calls this from its own rescue: a raise here would defeat the
-      # never-raises guarantee). f-l08-4: Wild.config.audit_logger defaults to
-      # nil, so without the warn fallback a single writer failure was
-      # terminally silent while ALLOW/DENY was still returned. Kernel#warn
-      # ($stderr) is always available and keeps "audit failure is never
-      # doubly silent" true out of the box, not only when a caller explicitly
-      # configures a logger.
-      def log_audit_failure(error, result)
-        message = build_audit_failure_message(error, result)
-        logger = Wild.config.audit_logger
-        logger.respond_to?(:error) ? logger.error(message) : warn(message)
-      rescue StandardError
-        # The configured logger raised from #error, or message construction
-        # itself raised. Rebuild the message fresh rather than rely on a
-        # binding from the failed attempt; only an unwritable $stderr defeats
-        # this last resort.
-        begin
-          warn build_audit_failure_message(error, result)
-        rescue StandardError
-          nil
-        end
-      end
-
-      # error.class is always safe; error.message is guarded via safe_message
-      # (a pathological exception whose #message raises must not turn a
-      # should-have-logged into terminal silence). Armstrong F2 fast-follow
-      # finding 4 (wild-wxk).
-      def build_audit_failure_message(error, result)
-        "[wild:capability_gate] audit emission failed: #{error.class}: #{safe_message(error)} " \
-          "(caller=#{result.caller_id.inspect} capability=#{result.capability_name.inspect} " \
-          "reason=#{result.reason.inspect})"
-      end
     end
 
     # The core access decision engine.
@@ -104,6 +59,11 @@ module Wild
     # 4. ALLOW
     #
     # See also: 003-TQ-STND-governance-model.md (fail-closed, no implicit grants)
+    # rubocop:disable Metrics/ClassLength -- carries the full decision tree AND
+    # the f-l08 addendum's audit-failure logging helpers (log_audit_failure/
+    # write_stderr/build_audit_failure_message); those exist only to serve this
+    # class's own never-raises guarantee, so splitting them out would separate
+    # the guarantee from its enforcement.
     class Evaluator
       include SafeCoercion
 
@@ -125,7 +85,12 @@ module Wild
 
       # Evaluate whether the caller is granted the named capability.
       # Context provides runtime values for prerequisite checks (e.g., config values).
-      # Returns an EvaluationResult — always, never raises.
+      # Returns an EvaluationResult for every genuine policy/runtime outcome —
+      # never raises for those. The one exception is a DEVELOPER_ERRORS member
+      # (a non-conforming audit event, or audit-schema validation enabled with
+      # `json_schemer` absent): that is a developer bug, not a runtime fault,
+      # and is re-raised deliberately rather than degraded to a silent denial
+      # (f-l08-2/f-l08-3).
       #
       # When an audit_writer is configured, every evaluation emits an audit event
       # before the result is returned. This satisfies the audit completeness rule
@@ -133,6 +98,15 @@ module Wild
       def evaluate(caller_id:, capability_name:, context: {})
         capability_name = capability_name.to_sym
         caller_id = String(caller_id)
+        # f-l08 addendum item 10: coerce ONCE, here, and pass the SAME coerced
+        # Hash to both the prerequisite checker and emit_audit. Previously the
+        # prerequisite checker saw the raw (possibly hostile) context while
+        # emit_audit recorded a separately, safely coerced one — a String
+        # context crashed ConfigValueChecker (masked as an ordinary
+        # prerequisite_not_met denial by its own rescue) while the audit trail
+        # recorded `{}`, an inconsistency between what was decided on and what
+        # was audited. Audit::Event.coerce_context never raises.
+        context = Audit::Event.coerce_context(context)
 
         result = check_capability_known(caller_id, capability_name) ||
                  check_caller_granted(caller_id, capability_name) ||
@@ -141,13 +115,13 @@ module Wild
 
         emit_audit(result, context)
         result
-      rescue Wild::CapabilityGate::AuditSchemaError, Wild::ConfigurationError
+      rescue *DEVELOPER_ERRORS
         # F2 (wild-rvv.4.1.2) + f-l08-2: a non-conforming audit event, or an
         # audit-validator misconfiguration (validation enabled but the
-        # `json_schemer` gem is absent: schema_validator.rb's ConfigurationError),
-        # is a developer bug, not a runtime fault: surface it loudly rather than
-        # let it degrade to a silent ALLOW/DENY with zero audit and zero log. This
-        # only fires when validation is enabled (dev/test by default), so
+        # `json_schemer` gem is absent: AuditValidatorUnavailableError), is a
+        # developer bug, not a runtime fault: surface it loudly rather than
+        # let it degrade to a silent ALLOW/DENY with zero audit and zero log.
+        # This only fires when validation is enabled (dev/test by default), so
         # production (validation off) keeps the never-raises guarantee untouched.
         # Must come BEFORE the StandardError rescue, or either error would be
         # misreported as an evaluation_error denial.
@@ -158,8 +132,9 @@ module Wild
         # today, so this is defense-in-depth: a corrupted registry/grant, a
         # future checker bug, or Event construction blowing up must NOT produce
         # a silent denial. Deny with reason :evaluation_error and emit the
-        # matching audit event before returning. Re-raise nothing — the gate
-        # never raises out of evaluate.
+        # matching audit event before returning. Re-raise nothing here — every
+        # StandardError other than a DEVELOPER_ERRORS member fails closed
+        # instead of escaping evaluate.
         error_result = deny_evaluation_error(caller_id, capability_name, e)
         emit_audit(error_result, context)
         error_result
@@ -232,45 +207,94 @@ module Wild
       # Called after every evaluation, before the result is returned to the caller.
       # An audit-write failure must not cause the gate to raise (fail-closed
       # still applies) — but per F2 (council rev2) it must NOT be doubly silent
-      # either: the failure is logged to Wild.config.audit_logger so an
-      # audit-pipeline outage is itself observable. Audit failure ≠ silent.
+      # either: the failure is logged (Wild.config.audit_logger, or $stderr as a
+      # fallback) so an audit-pipeline outage is itself observable. Audit
+      # failure ≠ silent.
       def emit_audit(result, context)
         return unless @audit_writer
 
-        # f-l08-1: coerce defensively BEFORE Event construction. A hostile
-        # `context` (a String, a non-pair Array, an object whose #to_hash
-        # raises) used to blow up `Hash(context)` inside Audit::Event#initialize;
-        # that raise was caught below by the StandardError rescue and, with the
-        # default nil audit_logger, produced zero audit record and zero log line
-        # for an ALLOW/DENY that had already been decided. safe_context never
-        # raises, so event construction always succeeds and this method's own
-        # rescue clauses are reserved for genuine write/validation failures.
+        # `context` arrives already coerced (evaluate coerces it once, up
+        # front — f-l08 addendum item 10); Event#initialize also re-coerces
+        # defensively as a total-construction backstop for any other caller of
+        # Event.new, so passing it through again here is cheap and safe, never
+        # a second source of truth.
         event = Audit::Event.from_evaluation(
-          result, registry: @registry, session_id: @session_id, context: safe_context(context)
+          result, registry: @registry, session_id: @session_id, context: context
         )
+        # f-l08 addendum item 13: build the hash once, hand the SAME hash to
+        # both the validator and the writer, rather than each independently
+        # calling event.to_h.
+        event_hash = event.to_h
         # F2 (wild-rvv.4.1.2): in dev/test, prove the event conforms to
         # audit_event.yml BEFORE it is written. A schema violation re-raises
-        # (caught by evaluate's AuditSchemaError rescue → surfaces as a dev/test
+        # (caught by evaluate's DEVELOPER_ERRORS rescue → surfaces as a dev/test
         # failure); it is NOT swallowed by the StandardError rescue below, which
         # exists for genuine write/IO failures. Off in prod by default.
-        Audit::SchemaValidator.validate!(event.to_h) if Audit::SchemaValidator.enabled?
-        @audit_writer.write(event)
-      rescue Wild::CapabilityGate::AuditSchemaError, Wild::ConfigurationError
+        Audit::SchemaValidator.validate!(event_hash) if Audit::SchemaValidator.enabled?
+        @audit_writer.write(event_hash)
+      rescue *DEVELOPER_ERRORS
         # f-l08-2: SchemaValidator.validate! (via its private `schemer` method)
-        # raises Wild::ConfigurationError when validation is enabled but the
-        # `json_schemer` gem is not on the bundle. That was previously caught by
-        # the StandardError rescue below and, with audit_logger nil by default,
-        # every evaluation silently returned ALLOW/DENY with zero audit and zero
-        # log: an absent dev dependency should fail loudly at first use, not
-        # degrade the gate's audit trail. Re-raise here, ordered before
-        # StandardError, exactly as AuditSchemaError already does.
+        # raises AuditValidatorUnavailableError when validation is enabled but
+        # the `json_schemer` gem is not on the bundle. That was previously
+        # caught by the StandardError rescue below and, with audit_logger nil
+        # by default, every evaluation silently returned ALLOW/DENY with zero
+        # audit and zero log: an absent dev dependency should fail loudly at
+        # first use, not degrade the gate's audit trail. Re-raise here, ordered
+        # before StandardError, exactly as the schema-conformance case does.
         raise
       rescue StandardError => e
-        # log_audit_failure lives in SafeCoercion (never raises out of here by
-        # contract; also shared with the module's other never-raising helpers).
         log_audit_failure(e, result)
         nil
       end
+
+      # Log an audit emission failure without ever raising (this method's own
+      # caller, emit_audit's rescue, must not raise either — that would defeat
+      # the never-raises guarantee). f-l08-4: Wild.config.audit_logger defaults
+      # to nil, so without a fallback a single writer failure was terminally
+      # silent while ALLOW/DENY was still returned.
+      #
+      # f-l08 addendum item 1: `Kernel#warn` is a no-op when `$VERBOSE` is nil
+      # (`ruby -W0`, `RUBYOPT=-W0`, a caller that runs under `silence_warnings`)
+      # — the specs here only ever passed because spec_helper.rb sets
+      # `config.warnings = false`, which does NOT affect `$VERBOSE`. Writing to
+      # `$stderr` directly keeps "audit failure is never doubly silent" true
+      # regardless of the process's warning-verbosity setting; only an
+      # unwritable $stderr defeats this last resort.
+      def log_audit_failure(error, result)
+        message = build_audit_failure_message(error, result)
+        logger = Wild.config.audit_logger
+        logger.respond_to?(:error) ? logger.error(message) : write_stderr(message)
+      rescue StandardError
+        # The configured logger raised from #error, or message construction
+        # itself raised (message stays nil in that case — Ruby has already
+        # declared the local by the time this rescue runs). Reuse the message
+        # we already built when we have one instead of rebuilding it (which
+        # would risk raising the exact same way twice); fall back to a
+        # class-only line when we don't.
+        write_stderr(message || "[wild:capability_gate] audit emission failed: #{error.class}")
+      end
+
+      # @api private
+      # rubocop:disable Style/StderrPuts -- deliberate: `warn` is a Kernel#warn
+      # no-op under $VERBOSE = nil (ruby -W0, silence_warnings), which is
+      # exactly the f-l08 addendum item 1 finding this bypasses.
+      def write_stderr(line)
+        $stderr.puts(line)
+      rescue StandardError
+        nil
+      end
+      # rubocop:enable Style/StderrPuts
+
+      # error.class is always safe; error.message is guarded via safe_message
+      # (a pathological exception whose #message raises must not turn a
+      # should-have-logged into terminal silence). Armstrong F2 fast-follow
+      # finding 4 (wild-wxk).
+      def build_audit_failure_message(error, result)
+        "[wild:capability_gate] audit emission failed: #{error.class}: #{safe_message(error)} " \
+          "(caller=#{result.caller_id.inspect} capability=#{result.capability_name.inspect} " \
+          "reason=#{result.reason.inspect})"
+      end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/wild/capability_gate/gate.rb
+++ b/lib/wild/capability_gate/gate.rb
@@ -34,11 +34,20 @@ module Wild
 
       # Evaluate whether the caller is granted the named capability.
       #
-      # Returns an EvaluationResult — always. Never raises.
-      # If evaluation fails for any reason, the result is denial with
-      # reason :evaluation_error (fail-closed per Doc 003).
+      # Returns an EvaluationResult for every policy/runtime outcome, never
+      # raises for those. If evaluation fails for any reason at that layer, the
+      # result is denial with reason :evaluation_error (fail-closed per Doc 003).
+      #
+      # f-l08-3: a developer-facing config/schema bug (a non-conforming audit
+      # event, or audit-schema validation enabled with `json_schemer` absent)
+      # is NOT a policy/runtime outcome, it re-raises through this method,
+      # matching #initialize's existing "raises on configuration errors, does
+      # not silently swallow them" contract, rather than being demoted to an
+      # audit-blind :evaluation_error denial.
       def evaluate(caller:, capability:, context: {})
         @evaluator.evaluate(caller_id: caller, capability_name: capability, context: context)
+      rescue Wild::CapabilityGate::AuditSchemaError, Wild::ConfigurationError
+        raise
       rescue StandardError => e
         deny_with_error(caller, capability, e)
       end
@@ -60,15 +69,25 @@ module Wild
         )
       end
 
-      # Last-resort safety net. Reaching here means Evaluator#evaluate broke
-      # its never-raises contract — that is a BUG, not a policy outcome, and
-      # this path is audit-blind BY CONSTRUCTION (the Gate holds no audit
-      # writer; emission lives in the Evaluator where the writer is). The
-      # Evaluator's own rescue emits the evaluation_error event for every
-      # real failure; if execution reaches here the Evaluator's contract has
-      # been violated and the missing audit event is the signal. Pinned by a
-      # Gate-rescue contract test (wild-rvv.4.1 fast-follow per Armstrong F2
-      # sign-off). Still fails closed.
+      # Last-resort safety net for genuine runtime/policy failures. Reaching
+      # here means Evaluator#evaluate raised something other than the two
+      # config/schema errors #evaluate re-raises above: that is a BUG, not a
+      # policy outcome, and this path is audit-blind BY CONSTRUCTION (the Gate
+      # holds no audit writer; emission lives in the Evaluator where the
+      # writer is). The Evaluator's own rescue emits the evaluation_error
+      # event for every real failure; if execution reaches here the
+      # Evaluator's contract has been violated and the missing audit event is
+      # the signal. Pinned by a Gate-rescue contract test (wild-rvv.4.1
+      # fast-follow per Armstrong F2 sign-off). Still fails closed.
+      #
+      # f-l08-3 correction: this rescue is NOT unreachable today (a prior
+      # version of this comment, and gate_spec.rb, both claimed it was).
+      # Evaluator#evaluate deliberately re-raises AuditSchemaError, and this
+      # StandardError rescue used to be the ONLY thing catching it: silently
+      # demoting a "surface loudly" developer-bug signal into an audit-blind
+      # :evaluation_error denial. The explicit rescue added above now
+      # intercepts AuditSchemaError and ConfigurationError before they reach
+      # here.
       def deny_with_error(caller_value, capability, error)
         EvaluationResult.denied(
           capability_name: capability || :unknown,

--- a/lib/wild/capability_gate/gate.rb
+++ b/lib/wild/capability_gate/gate.rb
@@ -12,7 +12,7 @@ module Wild
     #   result = gate.evaluate(caller: "service-account:agent", capability: :basic_introspection)
     #   result.allowed? # => true
     #
-    # See 006-AT-STND-interface-contract.md for the full interface specification.
+    # See 003-AT-ARCH-architecture.md for the full interface specification.
     class Gate
       # Initialize the gate from a configuration directory.
       #
@@ -25,9 +25,16 @@ module Wild
       #   - session_id: session identifier for audit events
       #
       # Raises on configuration errors — broken config must be caught at startup,
-      # not silently swallowed during evaluation.
+      # not silently swallowed during evaluation. f-l08 addendum item 2b: when
+      # an audit_log_path is given (so evaluations WILL try to emit audit
+      # events) and audit-schema validation would run, this probes that the
+      # validator is actually usable right here, at construction, instead of
+      # waiting for the first #evaluate call to discover a missing
+      # `json_schemer` gem in production. SchemaValidator's own first-use raise
+      # (inside #validate!) stays in place as a backstop.
       def initialize(config_path:, audit_log_path: nil, session_id: nil)
         config_path = String(config_path)
+        probe_schema_validator! if audit_log_path
         @evaluator = build_evaluator(config_path, audit_log_path, session_id)
         @registry = Registry.from_file(File.join(config_path, "capabilities.yml"))
       end
@@ -46,7 +53,7 @@ module Wild
       # audit-blind :evaluation_error denial.
       def evaluate(caller:, capability:, context: {})
         @evaluator.evaluate(caller_id: caller, capability_name: capability, context: context)
-      rescue Wild::CapabilityGate::AuditSchemaError, Wild::ConfigurationError
+      rescue *DEVELOPER_ERRORS
         raise
       rescue StandardError => e
         deny_with_error(caller, capability, e)
@@ -60,6 +67,11 @@ module Wild
 
       private
 
+      # @api private
+      def probe_schema_validator!
+        Audit::SchemaValidator.ensure_available! if Audit::SchemaValidator.enabled?
+      end
+
       def build_evaluator(config_path, audit_log_path, session_id)
         audit_writer = audit_log_path ? Audit::JsonLinesWriter.new(path: audit_log_path) : nil
         Evaluator.from_files(
@@ -70,24 +82,25 @@ module Wild
       end
 
       # Last-resort safety net for genuine runtime/policy failures. Reaching
-      # here means Evaluator#evaluate raised something other than the two
-      # config/schema errors #evaluate re-raises above: that is a BUG, not a
-      # policy outcome, and this path is audit-blind BY CONSTRUCTION (the Gate
-      # holds no audit writer; emission lives in the Evaluator where the
-      # writer is). The Evaluator's own rescue emits the evaluation_error
-      # event for every real failure; if execution reaches here the
-      # Evaluator's contract has been violated and the missing audit event is
-      # the signal. Pinned by a Gate-rescue contract test (wild-rvv.4.1
-      # fast-follow per Armstrong F2 sign-off). Still fails closed.
+      # here means Evaluator#evaluate raised something other than a
+      # DEVELOPER_ERRORS member (#evaluate re-raises those above): that is a
+      # BUG, not a policy outcome, and this path is audit-blind BY
+      # CONSTRUCTION (the Gate holds no audit writer; emission lives in the
+      # Evaluator where the writer is). The Evaluator's own rescue emits the
+      # evaluation_error event for every real failure; if execution reaches
+      # here the Evaluator's contract has been violated and the missing audit
+      # event is the signal. Pinned by a Gate-rescue contract test
+      # (wild-rvv.4.1 fast-follow per Armstrong F2 sign-off). Still fails
+      # closed.
       #
       # f-l08-3 correction: this rescue is NOT unreachable today (a prior
       # version of this comment, and gate_spec.rb, both claimed it was).
       # Evaluator#evaluate deliberately re-raises AuditSchemaError, and this
       # StandardError rescue used to be the ONLY thing catching it: silently
       # demoting a "surface loudly" developer-bug signal into an audit-blind
-      # :evaluation_error denial. The explicit rescue added above now
-      # intercepts AuditSchemaError and ConfigurationError before they reach
-      # here.
+      # :evaluation_error denial. The explicit `rescue *DEVELOPER_ERRORS` added
+      # above now intercepts it (and its subclass AuditValidatorUnavailableError)
+      # before they reach here.
       def deny_with_error(caller_value, capability, error)
         EvaluationResult.denied(
           capability_name: capability || :unknown,

--- a/lib/wild/error.rb
+++ b/lib/wild/error.rb
@@ -55,10 +55,15 @@ module Wild
     class PolicyError < Error; end
 
     # F2 mandate: marks the "gate machinery itself broke" failure mode. The
-    # shipped contract is fail-closed-DENY, not raise: when a `rescue` path in
-    # `Evaluator#evaluate` catches a raise, it emits a structured audit event
-    # with `result: "evaluation_error"` and returns a denial — it never raises
-    # out of `evaluate`. Never silent: always paired with an audit event,
+    # shipped contract is fail-closed-DENY for genuine runtime/policy
+    # failures: when `Evaluator#evaluate`'s `StandardError` rescue catches a
+    # raise, it emits a structured audit event with `result:
+    # "evaluation_error"` and returns a denial. The one deliberate exception
+    # is a DEVELOPER_ERRORS member (AuditSchemaError and its subclass
+    # AuditValidatorUnavailableError): those re-raise out of `evaluate`
+    # instead of being demoted to a denial (f-l08-2/f-l08-3) — a developer bug
+    # must surface loudly, not degrade the audit trail. Never silent: every
+    # non-DEVELOPER_ERRORS failure is always paired with an audit event,
     # emitted BEFORE the denial is returned (see audit_liveness_spec ordering
     # examples, wild-rvv.4.1.1).
     #
@@ -76,6 +81,20 @@ module Wild
     # (validation off) never raises this — the never-raises guarantee is a
     # production guarantee.
     class AuditSchemaError < Error; end
+
+    # Raised specifically when audit-event validation is enabled but the
+    # `json_schemer` development gem is not on the bundle (f-l08-2). Subclasses
+    # AuditSchemaError, NOT Wild::ConfigurationError, so a single
+    # `DEVELOPER_ERRORS = [AuditSchemaError]` whitelist at this namespace's
+    # rescue sites (evaluator.rb, gate.rb) re-raises every developer-bug signal
+    # from CapabilityGate with one class check, without also having to
+    # whitelist the gem-wide Wild::ConfigurationError — which would let an
+    # unrelated ConfigurationError from a future prerequisite checker escape
+    # Evaluator#evaluate before its emit_audit call runs (f-l08 addendum item
+    # 12). The message stays worded like a configuration problem even though
+    # the class is not; deliberately not multiply-inherited from both
+    # AuditSchemaError and ConfigurationError.
+    class AuditValidatorUnavailableError < AuditSchemaError; end
   end
 
   module Introspection

--- a/spec/wild/admin_tools/identity/authenticated_pipeline_spec.rb
+++ b/spec/wild/admin_tools/identity/authenticated_pipeline_spec.rb
@@ -104,6 +104,29 @@ RSpec.describe Wild::AdminTools::Identity::AuthenticatedPipeline do
       end
     end
 
+    # f-l08-3 (item 3): a CapabilityGate developer-bug signal must propagate
+    # through the whole T4 -> T3 chain (GateClient -> AuthenticatedPipeline)
+    # rather than being demoted to an ordinary "gate_denied" the way an actual
+    # gate malfunction is. authorize_via_gate only rescues Wild::AdminTools::
+    # GateError, so an AuditSchemaError re-raised by GateClient reaches here
+    # unrescued.
+    context "when gate raises a developer-bug error (AuditSchemaError)" do
+      let(:broken_gate) do
+        Object.new.tap do |g|
+          def g.evaluate(**_args)
+            raise Wild::CapabilityGate::AuditSchemaError, "audit event does not conform to audit_event.yml"
+          end
+        end
+      end
+      let(:gate_client) { Wild::AdminTools::Identity::GateClient.new(gate: broken_gate) }
+
+      it "propagates the developer error rather than demoting it to a gate_denied result" do
+        expect do
+          pipeline.call("inspect_job", { job_id: "job_1" }, { caller_id: "user_1" })
+        end.to raise_error(Wild::CapabilityGate::AuditSchemaError, /does not conform/)
+      end
+    end
+
     context "with mutation (two-phase)" do
       before do
         Wild::AdminTools.configuration.job_adapter.seed_job(

--- a/spec/wild/admin_tools/identity/gate_client_spec.rb
+++ b/spec/wild/admin_tools/identity/gate_client_spec.rb
@@ -93,6 +93,48 @@ RSpec.describe Wild::AdminTools::Identity::GateClient do
       end
     end
 
+    # f-l08-3 (item 3): a CapabilityGate developer-bug signal must not be
+    # demoted to an ordinary GateError — AuthenticatedPipeline only rescues
+    # GateError, so wrapping this would let it get silently absorbed into a
+    # generic "gate_denied" downstream with the real cause discarded.
+    context "when gate raises a developer-bug error (AuditSchemaError)" do
+      let(:broken_gate) do
+        Object.new.tap do |g|
+          def g.evaluate(**_args)
+            raise Wild::CapabilityGate::AuditSchemaError, "audit event does not conform to audit_event.yml"
+          end
+        end
+      end
+      let(:client) { described_class.new(gate: broken_gate) }
+
+      it "re-raises the AuditSchemaError instead of wrapping it in GateError" do
+        expect do
+          client.authorize(session, "inspect_job")
+        end.to raise_error(Wild::CapabilityGate::AuditSchemaError, /does not conform/)
+      end
+
+      it "logs the developer error via Wild.config.audit_logger before re-raising" do
+        logger = instance_spy(Logger)
+        Wild.configure { |c| c.audit_logger = logger }
+
+        begin
+          client.authorize(session, "inspect_job")
+        rescue Wild::CapabilityGate::AuditSchemaError
+          nil
+        end
+
+        expect(logger).to have_received(:error).with(/AuditSchemaError/)
+      end
+
+      it "falls back to $stderr when no audit_logger is configured" do
+        expect do
+          client.authorize(session, "inspect_job")
+        rescue Wild::CapabilityGate::AuditSchemaError
+          nil
+        end.to output(/capability gate raised a developer error: Wild::CapabilityGate::AuditSchemaError/).to_stderr
+      end
+    end
+
     it "passes correct capability name to gate" do
       client.authorize(session, "retry_job")
       call = test_gate.calls.last

--- a/spec/wild/capability_gate/audit/audit_liveness_spec.rb
+++ b/spec/wild/capability_gate/audit/audit_liveness_spec.rb
@@ -366,24 +366,16 @@ RSpec.describe "Wild::CapabilityGate F2 audit liveness" do
   end
 
   describe "audit-event schema validation toggle (F2, wild-rvv.4.1.2)" do
-    # A deliberately non-conforming event injected at emit time. When validation
-    # is on (dev/test), the gate must SURFACE it (a non-conforming event is a
-    # developer bug); when off (prod default), the gate must NOT raise — its
-    # never-raises fail-closed guarantee is a production guarantee.
-    let(:bad_event) do
-      instance_double(Wild::CapabilityGate::Audit::Event, to_h: { "outcome" => "maybe" })
-    end
-
+    # Shared by every context below (f-l08 addendum item 9: previously this
+    # exact evaluator/evaluate! pair was independently redefined a FIFTH time
+    # a few contexts down for the json_schemer-absent scenario; defined once
+    # here instead).
     let(:evaluator) do
       Wild::CapabilityGate::Evaluator.from_files(
         capabilities_path: capabilities_path,
         grants_path: grants_path,
         audit_writer: collecting_writer
       )
-    end
-
-    before do
-      allow(Wild::CapabilityGate::Audit::Event).to receive(:from_evaluation).and_return(bad_event)
     end
 
     def evaluate!
@@ -393,104 +385,126 @@ RSpec.describe "Wild::CapabilityGate F2 audit liveness" do
       )
     end
 
-    context "when validate_audit_events = true" do
-      before { Wild.configure { |c| c.capability_gate.validate_audit_events = true } }
-
-      it "raises AuditSchemaError out of evaluate (surfaces the developer bug, not swallowed)" do
-        expect { evaluate! }.to raise_error(Wild::CapabilityGate::AuditSchemaError)
+    context "with a non-conforming event injected at emit time" do
+      # A deliberately non-conforming event injected at emit time. When validation
+      # is on (dev/test), the gate must SURFACE it (a non-conforming event is a
+      # developer bug); when off (prod default), the gate must NOT raise — its
+      # never-raises fail-closed guarantee is a production guarantee. The
+      # from_evaluation stub is scoped to THIS context only (not the describe
+      # block above) so the json_schemer-absent context below, which needs a
+      # real Event to reach SchemaValidator, is unaffected by it.
+      let(:bad_event) do
+        instance_double(Wild::CapabilityGate::Audit::Event, to_h: { "outcome" => "maybe" })
       end
 
-      it "does not write the non-conforming event" do
+      before do
+        allow(Wild::CapabilityGate::Audit::Event).to receive(:from_evaluation).and_return(bad_event)
+      end
+
+      context "when validate_audit_events = true" do
+        before { Wild.configure { |c| c.capability_gate.validate_audit_events = true } }
+
+        it "raises AuditSchemaError out of evaluate (surfaces the developer bug, not swallowed)" do
+          expect { evaluate! }.to raise_error(Wild::CapabilityGate::AuditSchemaError)
+        end
+
+        it "does not write the non-conforming event" do
+          begin
+            evaluate!
+          rescue Wild::CapabilityGate::AuditSchemaError
+            nil
+          end
+          expect(collecting_writer.events).to be_empty
+        end
+      end
+
+      context "when validate_audit_events = false (prod default posture)" do
+        before { Wild.configure { |c| c.capability_gate.validate_audit_events = false } }
+
+        it "does NOT raise — fail-closed never-raises guarantee preserved" do
+          expect { evaluate! }.not_to raise_error
+        end
+
+        it "still writes the event (validation off ≠ audit off)" do
+          evaluate!
+          expect(collecting_writer.events.size).to eq(1)
+        end
+      end
+
+      context "with :auto (default) — keys off Wild.config.environment" do
+        before { Wild.configure { |c| c.capability_gate.validate_audit_events = :auto } }
+
+        it "validates (raises) in :test" do
+          Wild.configure { |c| c.environment = :test }
+          expect { evaluate! }.to raise_error(Wild::CapabilityGate::AuditSchemaError)
+        end
+
+        it "skips validation (no raise) in :production" do
+          Wild.configure { |c| c.environment = :production }
+          expect { evaluate! }.not_to raise_error
+        end
+      end
+    end
+
+    # f-l08-2: validation enabled (default :auto is on in :development/:test,
+    # the default environment) but `json_schemer` is absent. This previously
+    # raised Wild::ConfigurationError from SchemaValidator's private `schemer`
+    # method, then got caught by emit_audit's blanket StandardError rescue and
+    # (with audit_logger nil by default) vanished: the evaluation returned
+    # ALLOW with zero audit event and zero log line. It must now surface
+    # loudly. f-l08 addendum item 12: the class raised is now
+    # AuditValidatorUnavailableError (a subclass of AuditSchemaError), not the
+    # gem-wide Wild::ConfigurationError, so DEVELOPER_ERRORS only needs to
+    # whitelist AuditSchemaError.
+    context "when json_schemer is not available (F2, f-l08-2)" do
+      before do
+        Wild::CapabilityGate::Audit::SchemaValidator.reset!
+        allow(Wild::CapabilityGate::Audit::SchemaValidator)
+          .to receive(:require).with("json_schemer").and_raise(LoadError)
+      end
+
+      after { Wild::CapabilityGate::Audit::SchemaValidator.reset! }
+
+      it "raises AuditValidatorUnavailableError out of Evaluator#evaluate (not swallowed to a silent ALLOW)" do
+        expect { evaluate! }.to raise_error(Wild::CapabilityGate::AuditValidatorUnavailableError, /json_schemer/)
+      end
+
+      # f-l08 addendum item 14: a prior version of this example pinned "zero
+      # audit events" as REQUIRED behavior. That over-specifies an incidental
+      # detail of where the raise happens to fire (before Audit::Event is
+      # even constructed), not a real contract. The actual invariant: evaluate!
+      # must never raise and then be indistinguishable from a quiet success.
+      # It already satisfies that by raising with a message naming the cause.
+      # If a future revision starts leaving a diagnostic trace before the
+      # raise, this only requires that trace to explain the abort (not read
+      # as an ordinary "allow"/"deny" outcome), not that no trace exists.
+      it "raises without ever looking like a silent success; any trace it leaves explains the abort" do
         begin
           evaluate!
-        rescue Wild::CapabilityGate::AuditSchemaError
+        rescue Wild::CapabilityGate::AuditValidatorUnavailableError
           nil
         end
-        expect(collecting_writer.events).to be_empty
-      end
-    end
-
-    context "when validate_audit_events = false (prod default posture)" do
-      before { Wild.configure { |c| c.capability_gate.validate_audit_events = false } }
-
-      it "does NOT raise — fail-closed never-raises guarantee preserved" do
-        expect { evaluate! }.not_to raise_error
+        collecting_writer.events.each do |event|
+          expect(event["outcome"]).not_to be_in(%w[allow deny])
+        end
       end
 
-      it "still writes the event (validation off ≠ audit off)" do
-        evaluate!
-        expect(collecting_writer.events.size).to eq(1)
+      # f-l08 addendum item 2b: Gate#initialize now probes the validator at
+      # construction time (when an audit_log_path is given), so this scenario
+      # now raises at Gate.new — earlier than the previous version of this
+      # example (which constructed the Gate first, then asserted the raise
+      # came from #evaluate).
+      it "raises out of Gate.new at construction time (boot-time probe, f-l08-3 extension)" do
+        log = Tempfile.new(["gate-schema-config", ".jsonl"])
+
+        expect do
+          Wild::CapabilityGate::Gate.new(
+            config_path: File.join(fixtures_dir, "config"), audit_log_path: log.path
+          )
+        end.to raise_error(Wild::CapabilityGate::AuditValidatorUnavailableError, /json_schemer/)
+      ensure
+        log.close!
       end
-    end
-
-    context "with :auto (default) — keys off Wild.config.environment" do
-      before { Wild.configure { |c| c.capability_gate.validate_audit_events = :auto } }
-
-      it "validates (raises) in :test" do
-        Wild.configure { |c| c.environment = :test }
-        expect { evaluate! }.to raise_error(Wild::CapabilityGate::AuditSchemaError)
-      end
-
-      it "skips validation (no raise) in :production" do
-        Wild.configure { |c| c.environment = :production }
-        expect { evaluate! }.not_to raise_error
-      end
-    end
-  end
-
-  # f-l08-2: validation enabled (default :auto is on in :development/:test,
-  # the default environment) but `json_schemer` is absent. This previously
-  # raised Wild::ConfigurationError from SchemaValidator's private `schemer`
-  # method, then got caught by emit_audit's blanket StandardError rescue and
-  # (with audit_logger nil by default) vanished: the evaluation returned
-  # ALLOW with zero audit event and zero log line. It must now surface loudly.
-  describe "audit-schema validator misconfigured (json_schemer absent, F2, f-l08-2)" do
-    let(:evaluator) do
-      Wild::CapabilityGate::Evaluator.from_files(
-        capabilities_path: capabilities_path,
-        grants_path: grants_path,
-        audit_writer: collecting_writer
-      )
-    end
-
-    before do
-      Wild::CapabilityGate::Audit::SchemaValidator.reset!
-      allow(Wild::CapabilityGate::Audit::SchemaValidator)
-        .to receive(:require).with("json_schemer").and_raise(LoadError)
-    end
-
-    after { Wild::CapabilityGate::Audit::SchemaValidator.reset! }
-
-    def evaluate!
-      evaluator.evaluate(
-        caller_id: "service-account:introspection-agent",
-        capability_name: :basic_introspection
-      )
-    end
-
-    it "raises Wild::ConfigurationError out of Evaluator#evaluate (not swallowed to a silent ALLOW)" do
-      expect { evaluate! }.to raise_error(Wild::ConfigurationError, /json_schemer/)
-    end
-
-    it "does not write an audit event for the aborted evaluation" do
-      begin
-        evaluate!
-      rescue Wild::ConfigurationError
-        nil
-      end
-      expect(collecting_writer.events).to be_empty
-    end
-
-    it "raises Wild::ConfigurationError out of Gate#evaluate too (f-l08-3 extension)" do
-      log = Tempfile.new(["gate-schema-config", ".jsonl"])
-      gate = Wild::CapabilityGate::Gate.new(
-        config_path: File.join(fixtures_dir, "config"), audit_log_path: log.path
-      )
-
-      expect { gate.evaluate(caller: "service-account:introspection-agent", capability: :basic_introspection) }
-        .to raise_error(Wild::ConfigurationError, /json_schemer/)
-    ensure
-      log.close!
     end
   end
 end

--- a/spec/wild/capability_gate/audit/audit_liveness_spec.rb
+++ b/spec/wild/capability_gate/audit/audit_liveness_spec.rb
@@ -306,12 +306,16 @@ RSpec.describe "Wild::CapabilityGate F2 audit liveness" do
     end
   end
 
-  describe "when BOTH the audit writer AND the logger are broken (terminal silent path)" do
-    # The one genuinely-terminal silent path, by design. It requires two
-    # simultaneous failures — writer raises on write, logger raises on error.
-    # The contract: the gate STILL does not raise and STILL returns its
-    # computed result. This pins Armstrong's F2 terminal-silence boundary so a
-    # refactor can't silently widen it.
+  describe "when BOTH the audit writer AND the configured logger are broken" do
+    # f-l08-4: this used to be the one genuinely-terminal silent path: writer
+    # raises on write, logger raises on #error, and log_audit_failure's `return
+    # unless logger.respond_to?(:error)` guard never even applied (a logger WAS
+    # configured here). Now log_audit_failure falls back to Kernel#warn
+    # ($stderr) when the configured logger itself blows up, so this dual
+    # failure is no longer terminally silent either: only an unwritable
+    # $stderr defeats it. The contract pinned here: the gate STILL does not
+    # raise and STILL returns its computed result, AND the failure is still
+    # observable on $stderr.
     let(:exploding_writer) do
       Class.new do
         def write(_event) = raise(IOError, "audit disk full")
@@ -349,6 +353,15 @@ RSpec.describe "Wild::CapabilityGate F2 audit liveness" do
         capability_name: :basic_introspection
       )
       expect(result).to be_allowed
+    end
+
+    it "falls back to $stderr instead of going fully silent (f-l08-4)" do
+      expect do
+        evaluator.evaluate(
+          caller_id: "service-account:introspection-agent",
+          capability_name: :basic_introspection
+        )
+      end.to output(/\[wild:capability_gate\] audit emission failed: IOError: audit disk full/).to_stderr
     end
   end
 
@@ -422,6 +435,62 @@ RSpec.describe "Wild::CapabilityGate F2 audit liveness" do
         Wild.configure { |c| c.environment = :production }
         expect { evaluate! }.not_to raise_error
       end
+    end
+  end
+
+  # f-l08-2: validation enabled (default :auto is on in :development/:test,
+  # the default environment) but `json_schemer` is absent. This previously
+  # raised Wild::ConfigurationError from SchemaValidator's private `schemer`
+  # method, then got caught by emit_audit's blanket StandardError rescue and
+  # (with audit_logger nil by default) vanished: the evaluation returned
+  # ALLOW with zero audit event and zero log line. It must now surface loudly.
+  describe "audit-schema validator misconfigured (json_schemer absent, F2, f-l08-2)" do
+    let(:evaluator) do
+      Wild::CapabilityGate::Evaluator.from_files(
+        capabilities_path: capabilities_path,
+        grants_path: grants_path,
+        audit_writer: collecting_writer
+      )
+    end
+
+    before do
+      Wild::CapabilityGate::Audit::SchemaValidator.reset!
+      allow(Wild::CapabilityGate::Audit::SchemaValidator)
+        .to receive(:require).with("json_schemer").and_raise(LoadError)
+    end
+
+    after { Wild::CapabilityGate::Audit::SchemaValidator.reset! }
+
+    def evaluate!
+      evaluator.evaluate(
+        caller_id: "service-account:introspection-agent",
+        capability_name: :basic_introspection
+      )
+    end
+
+    it "raises Wild::ConfigurationError out of Evaluator#evaluate (not swallowed to a silent ALLOW)" do
+      expect { evaluate! }.to raise_error(Wild::ConfigurationError, /json_schemer/)
+    end
+
+    it "does not write an audit event for the aborted evaluation" do
+      begin
+        evaluate!
+      rescue Wild::ConfigurationError
+        nil
+      end
+      expect(collecting_writer.events).to be_empty
+    end
+
+    it "raises Wild::ConfigurationError out of Gate#evaluate too (f-l08-3 extension)" do
+      log = Tempfile.new(["gate-schema-config", ".jsonl"])
+      gate = Wild::CapabilityGate::Gate.new(
+        config_path: File.join(fixtures_dir, "config"), audit_log_path: log.path
+      )
+
+      expect { gate.evaluate(caller: "service-account:introspection-agent", capability: :basic_introspection) }
+        .to raise_error(Wild::ConfigurationError, /json_schemer/)
+    ensure
+      log.close!
     end
   end
 end

--- a/spec/wild/capability_gate/audit/event_spec.rb
+++ b/spec/wild/capability_gate/audit/event_spec.rb
@@ -204,6 +204,89 @@ RSpec.describe Wild::CapabilityGate::Audit::Event do
     end
   end
 
+  describe ".coerce_context (f-l08 addendum items 4, 10, 11)" do
+    it "passes a real Hash through unchanged (by value)" do
+      expect(described_class.coerce_context({ "env" => "test" })).to eq({ "env" => "test" })
+    end
+
+    it "never returns the CALLER's own Hash object — dup'ing prevents the FrozenError trap" do
+      caller_hash = { "env" => "test" }
+      coerced = described_class.coerce_context(caller_hash)
+
+      expect(coerced).to eq(caller_hash)
+      expect(coerced).not_to equal(caller_hash)
+      expect(caller_hash).not_to be_frozen # the caller's own Hash is never touched
+    end
+
+    it "returns {} for nil (matches Hash(nil) semantics)" do
+      expect(described_class.coerce_context(nil)).to eq({})
+    end
+
+    it "degrades a String to a bounded, sanitized placeholder instead of raising" do
+      expect(described_class.coerce_context("not-a-hash")).to eq({ raw: '"not-a-hash"' })
+    end
+
+    it "degrades ANY non-empty Array — Kernel#Hash raises TypeError for pairs-shaped arrays too" do
+      expect(described_class.coerce_context(%w[x y])).to eq({ raw: "#<Array size=2>" })
+      expect(described_class.coerce_context([%w[a 1], %w[b 2]])).to eq({ raw: "#<Array size=2>" })
+    end
+
+    it "degrades an object whose #to_hash raises" do
+      hostile = Class.new { def to_hash = raise("boom") }.new
+      expect(described_class.coerce_context(hostile)).to eq({ raw: "#<#{hostile.class}>" })
+    end
+
+    it "redacts a secret-shaped token instead of writing it verbatim (item 4)" do
+      coerced = described_class.coerce_context("token=sk-live-abc123")
+      expect(coerced[:raw]).to include("REDACTED")
+      expect(coerced[:raw]).not_to include("sk-live-abc123")
+    end
+
+    it "does not call #inspect on a multi-megabyte String — slices before inspecting" do
+      huge = "x" * 5_000_000
+      expect { described_class.coerce_context(huge) }.not_to raise_error
+      coerced = described_class.coerce_context(huge)
+      expect(coerced[:raw].length).to be < 300
+    end
+
+    it "does not raise SystemStackError on a very deeply nested Array (never calls #inspect on it)" do
+      deep = 20_000.times.inject([]) { |acc, _| [acc] }
+      expect { described_class.coerce_context(deep) }.not_to raise_error
+      expect(described_class.coerce_context(deep)).to eq({ raw: "#<Array size=1>" })
+    end
+
+    it "replaces a Hash context containing NaN with a bounded, diagnosable summary" do
+      coerced = described_class.coerce_context({ "value" => Float::NAN, "other" => 1 })
+      expect(coerced).to eq({ truncated: true, keys: %w[value other] })
+    end
+
+    it "replaces an oversized Hash context (over the 2 KiB extra budget) with a bounded summary" do
+      big = { "blob" => "x" * 3000 }
+      coerced = described_class.coerce_context(big)
+      expect(coerced).to eq({ truncated: true, keys: ["blob"] })
+    end
+
+    it "keeps a small, JSON-safe Hash context exactly as given" do
+      small = { "env" => "test", "count" => 3 }
+      expect(described_class.coerce_context(small)).to eq(small)
+    end
+  end
+
+  describe "context construction never re-freezes the caller's own Hash (f-l08 addendum item 4)" do
+    it "does not raise FrozenError when the caller reuses the same context Hash for a second evaluation" do
+      shared_context = { "env" => "test" }
+      described_class.new(
+        timestamp: timestamp, subject: "svc:a", capability: "basic_introspection",
+        risk_level: "standard", outcome: "allow",
+        policy_version: Wild::CapabilityGate::Registry::UNKNOWN_POLICY_VERSION,
+        context: shared_context
+      )
+
+      expect(shared_context).not_to be_frozen
+      expect { shared_context["env"] = "production" }.not_to raise_error
+    end
+  end
+
   describe "outcome normalization (never raises — runs inside the rescue path)" do
     # F2: Event construction happens inside Evaluator#evaluate's rescue handler.
     # A raise here would re-open the silent-denial hole. So an unrecognized

--- a/spec/wild/capability_gate/audit/json_lines_writer_spec.rb
+++ b/spec/wild/capability_gate/audit/json_lines_writer_spec.rb
@@ -84,6 +84,62 @@ RSpec.describe Wild::CapabilityGate::Audit::JsonLinesWriter do
     end
   end
 
+  # f-l08 addendum item 5: Audit::Event.coerce_context already bounds `context`
+  # before an Event is even built (rejects NaN/Infinity, invalid encodings,
+  # oversized payloads), so this exercises the writer's OWN defense-in-depth
+  # for the case where #to_h returns unserializable data anyway (a double, or
+  # a future field this coercion doesn't cover) — the decision must still get
+  # written, not silently dropped because JSON.generate raised.
+  describe "#write when the event hash is not JSON-serializable" do
+    let(:nan_event) do
+      instance_double(
+        Wild::CapabilityGate::Audit::Event,
+        to_h: {
+          "timestamp" => "2026-03-17T12:00:00.000Z", "decision_id" => "d1",
+          "capability" => "basic_introspection", "subject" => "svc:a",
+          "outcome" => "allow", "policy_version" => "v1", "rationale" => "granted",
+          "reason" => nil, "risk_level" => "standard",
+          "prerequisites_checked" => [], "prerequisites_passed" => true,
+          "extra" => { "session_id" => nil, "context" => { "value" => Float::NAN } }
+        }
+      )
+    end
+
+    let(:binary_event) do
+      instance_double(
+        Wild::CapabilityGate::Audit::Event,
+        to_h: {
+          "timestamp" => "2026-03-17T12:00:00.000Z", "decision_id" => "d2",
+          "capability" => "basic_introspection", "subject" => "svc:a",
+          "outcome" => "allow", "policy_version" => "v1", "rationale" => "granted",
+          "reason" => nil, "risk_level" => "standard",
+          "prerequisites_checked" => [], "prerequisites_passed" => true,
+          "extra" => { "session_id" => nil, "context" => { "value" => "\xFF\xFE".dup.force_encoding("UTF-8") } }
+        }
+      )
+    end
+
+    it "still writes exactly one audit line for a NaN context instead of dropping the line" do
+      expect(writer.write(nan_event)).to be_nil
+
+      lines = File.readlines(log_file.path)
+      expect(lines.size).to eq(1)
+      parsed = JSON.parse(lines.first)
+      expect(parsed["decision_id"]).to eq("d1")
+      expect(parsed.dig("extra", "context")).to eq({ "dropped" => true, "reason" => "context not JSON-serializable" })
+    end
+
+    it "still writes exactly one audit line for invalid-encoding binary context" do
+      expect(writer.write(binary_event)).to be_nil
+
+      lines = File.readlines(log_file.path)
+      expect(lines.size).to eq(1)
+      parsed = JSON.parse(lines.first)
+      expect(parsed["decision_id"]).to eq("d2")
+      expect(parsed.dig("extra", "context")).to eq({ "dropped" => true, "reason" => "context not JSON-serializable" })
+    end
+  end
+
   describe "creates file if it does not exist" do
     it "creates the log file on first write" do
       new_path = "#{log_file.path}.new"

--- a/spec/wild/capability_gate/audit/schema_validator_spec.rb
+++ b/spec/wild/capability_gate/audit/schema_validator_spec.rb
@@ -47,6 +47,24 @@ RSpec.describe Wild::CapabilityGate::Audit::SchemaValidator do
     end
   end
 
+  # f-l08-2: validation enabled (:auto default resolves to on in dev/test) but
+  # `json_schemer` is a development-only gem (wild.gemspec) that a consuming
+  # app may not have added. Prove the LoadError becomes a loud, greppable
+  # Wild::ConfigurationError at first use rather than the LoadError itself
+  # (which previously reached emit_audit's blanket StandardError rescue and,
+  # with audit_logger nil by default, vanished with zero audit and zero log).
+  describe ".validate! when json_schemer is not available" do
+    after { described_class.reset! }
+
+    it "raises Wild::ConfigurationError, not a bare LoadError" do
+      described_class.reset!
+      allow(described_class).to receive(:require).with("json_schemer").and_raise(LoadError)
+
+      expect { described_class.validate!(conforming) }
+        .to raise_error(Wild::ConfigurationError, /json_schemer/)
+    end
+  end
+
   describe ".valid?" do
     it "is true for a conforming event and false otherwise" do
       expect(described_class.valid?(conforming)).to be true

--- a/spec/wild/capability_gate/audit/schema_validator_spec.rb
+++ b/spec/wild/capability_gate/audit/schema_validator_spec.rb
@@ -50,18 +50,51 @@ RSpec.describe Wild::CapabilityGate::Audit::SchemaValidator do
   # f-l08-2: validation enabled (:auto default resolves to on in dev/test) but
   # `json_schemer` is a development-only gem (wild.gemspec) that a consuming
   # app may not have added. Prove the LoadError becomes a loud, greppable
-  # Wild::ConfigurationError at first use rather than the LoadError itself
-  # (which previously reached emit_audit's blanket StandardError rescue and,
-  # with audit_logger nil by default, vanished with zero audit and zero log).
+  # error at first use rather than the LoadError itself (which previously
+  # reached emit_audit's blanket StandardError rescue and, with audit_logger
+  # nil by default, vanished with zero audit and zero log). f-l08 addendum
+  # item 12: the class is AuditValidatorUnavailableError (a subclass of
+  # AuditSchemaError), NOT the gem-wide Wild::ConfigurationError — kept out of
+  # that hierarchy on purpose so CapabilityGate's DEVELOPER_ERRORS whitelist
+  # can re-raise every developer-bug signal from THIS namespace with a single
+  # AuditSchemaError check, without also giving a free pass to an unrelated
+  # ConfigurationError a future prerequisite checker might raise. The message
+  # still reads like a configuration problem even though the class is not.
   describe ".validate! when json_schemer is not available" do
     after { described_class.reset! }
 
-    it "raises Wild::ConfigurationError, not a bare LoadError" do
+    it "raises AuditValidatorUnavailableError (an AuditSchemaError), not a bare LoadError or ConfigurationError" do
       described_class.reset!
       allow(described_class).to receive(:require).with("json_schemer").and_raise(LoadError)
 
       expect { described_class.validate!(conforming) }
-        .to raise_error(Wild::ConfigurationError, /json_schemer/)
+        .to raise_error(Wild::CapabilityGate::AuditValidatorUnavailableError, /json_schemer/)
+    end
+
+    it "is-a AuditSchemaError (covered by CapabilityGate::DEVELOPER_ERRORS with one class check)" do
+      described_class.reset!
+      allow(described_class).to receive(:require).with("json_schemer").and_raise(LoadError)
+
+      expect { described_class.validate!(conforming) }.to raise_error(Wild::CapabilityGate::AuditSchemaError)
+    end
+
+    it "is NOT a Wild::ConfigurationError (deliberately not multiply-inherited)" do
+      described_class.reset!
+      allow(described_class).to receive(:require).with("json_schemer").and_raise(LoadError)
+
+      begin
+        described_class.validate!(conforming)
+      rescue Wild::CapabilityGate::AuditValidatorUnavailableError => e
+        expect(e).not_to be_a(Wild::ConfigurationError)
+      end
+    end
+
+    it "exercises the Gate#initialize boot-time probe path directly (ensure_available!)" do
+      described_class.reset!
+      allow(described_class).to receive(:require).with("json_schemer").and_raise(LoadError)
+
+      expect { described_class.ensure_available! }
+        .to raise_error(Wild::CapabilityGate::AuditValidatorUnavailableError, /json_schemer/)
     end
   end
 
@@ -69,6 +102,43 @@ RSpec.describe Wild::CapabilityGate::Audit::SchemaValidator do
     it "is true for a conforming event and false otherwise" do
       expect(described_class.valid?(conforming)).to be true
       expect(described_class.valid?(conforming.merge("outcome" => "maybe"))).to be false
+    end
+  end
+
+  # f-l08 addendum item 2: nothing in this gem sets Wild.config.environment
+  # from Rails.env, so a real Rails app that never touches
+  # Wild.config.environment would silently stay on its :development default
+  # even in production — and json_schemer is a DEVELOPMENT-only gem, so a
+  # production app without it would have raised on EVERY evaluation. .enabled?
+  # now consults the real Rails.env first (production forces validation off)
+  # before falling back to the pre-existing Wild.config.environment check.
+  describe ".enabled? in a real Rails production environment" do
+    # Wild.reset_config! runs before every example (spec_helper.rb), so no
+    # manual save/restore of Wild.config.environment is needed here.
+    before { Wild.configure { |c| c.capability_gate.validate_audit_events = :auto } }
+
+    it "is off when Rails.env is production, even though Wild.config.environment was never updated" do
+      # The exact bug this closes: Wild.config.environment stays at its
+      # :development default (nothing wires it from Rails.env), which alone
+      # would make .enabled? return true here.
+      Wild.configure { |c| c.environment = :development }
+      allow(Rails.env).to receive(:production?).and_return(true)
+
+      expect(described_class.enabled?).to be false
+    end
+
+    it "falls back to Wild.config.environment when Rails.env is not production" do
+      Wild.configure { |c| c.environment = :test }
+      allow(Rails.env).to receive(:production?).and_return(false)
+
+      expect(described_class.enabled?).to be true
+    end
+
+    it "does not raise if Rails.env itself misbehaves (defensive fallback)" do
+      allow(Rails).to receive(:env).and_raise("Rails.env exploded")
+      Wild.configure { |c| c.environment = :test }
+
+      expect(described_class.enabled?).to be true
     end
   end
 end

--- a/spec/wild/capability_gate/evaluator_spec.rb
+++ b/spec/wild/capability_gate/evaluator_spec.rb
@@ -364,6 +364,62 @@ RSpec.describe Wild::CapabilityGate::Evaluator do
       end
     end
 
+    # f-l08 addendum item 10 + 14: prove the INVARIANT — the prerequisite
+    # checker and the audit trail see the SAME coerced context — rather than
+    # merely asserting "hostile input still returns ALLOW". Uses a capability
+    # with a config_value prerequisite (unlike basic_introspection, which has
+    # none) so a hostile context actually reaches ConfigValueChecker, the
+    # collaborator that used to crash on it.
+    context "with a hostile context reaching a config_value prerequisite" do
+      # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength -- one coherent invariant: checker + audit see the same coerced context
+      it "denies on a legible business reason (checker sees the coerced context, not the raw hostile one)" do
+        attestation_file = Tempfile.new("safety-attestation")
+        prereqs = [
+          Wild::CapabilityGate::Prerequisite.new(type: :file_exists, path: attestation_file.path),
+          Wild::CapabilityGate::Prerequisite.new(type: :config_value, key: "admin_tools_enabled", value: true)
+        ]
+        capability = Wild::CapabilityGate::Capability.new(
+          name: :gated_capability, description: "Test gated capability",
+          risk_level: :critical, prerequisites: prereqs
+        )
+        grants = [
+          Wild::CapabilityGate::Grant.new(caller_id: "service-account:admin-agent", capabilities: [:gated_capability])
+        ]
+        ev = described_class.new(
+          registry: Wild::CapabilityGate::Registry.new([capability]),
+          grants: grants,
+          audit_writer: audit_writer
+        )
+
+        result = ev.evaluate(
+          caller_id: "service-account:admin-agent",
+          capability_name: :gated_capability,
+          context: "not-a-hash"
+        )
+
+        # BEFORE the fix: ConfigValueChecker#lookup called `context.key?` on
+        # the raw String, raised NoMethodError, and its own rescue masked that
+        # as a generic "config_value check failed: NoMethodError" — while the
+        # audit trail recorded a SEPARATELY (safely) coerced `{}` for the same
+        # evaluation, an inconsistency between what was decided on and what
+        # was audited. AFTER the fix: the checker sees the SAME coerced Hash
+        # the audit trail records, so it fails on a legible "key missing"
+        # business reason instead of an internal-error message.
+        expect(result).to be_denied
+        expect(result.reason).to eq(:prerequisite_not_met)
+        expect(result.details).to include("admin_tools_enabled")
+        expect(result.details).not_to include("NoMethodError")
+
+        events = parse_audit_log
+        expect(events.size).to eq(1)
+        expected_context = JSON.parse(JSON.generate(Wild::CapabilityGate::Audit::Event.coerce_context("not-a-hash")))
+        expect(events.first.dig("extra", "context")).to eq(expected_context)
+      ensure
+        attestation_file.close!
+      end
+      # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength
+    end
+
     context "when no audit writer is configured" do
       it "does not write any audit log" do
         ev = described_class.from_files(
@@ -404,8 +460,8 @@ RSpec.describe Wild::CapabilityGate::Evaluator do
       # log_audit_failure's `return unless logger.respond_to?(:error)` fired
       # and there was nowhere else the failure was recorded, while the CHANGELOG
       # claimed only a simultaneous writer-AND-logger outage was terminal.
-      # Kernel#warn ($stderr) is now the default-config fallback.
-      it "falls back to Kernel#warn on $stderr when no audit_logger is configured" do
+      # Writing directly to $stderr is now the default-config fallback.
+      it "falls back to $stderr when no audit_logger is configured" do
         broken_writer = instance_double(Wild::CapabilityGate::Audit::JsonLinesWriter)
         allow(broken_writer).to receive(:write).and_raise(IOError, "disk full")
 
@@ -419,7 +475,43 @@ RSpec.describe Wild::CapabilityGate::Evaluator do
           ev.evaluate(caller_id: "service-account:introspection-agent", capability_name: :basic_introspection)
         end.to output(/\[wild:capability_gate\] audit emission failed: IOError: disk full/).to_stderr
       end
+
+      # f-l08 addendum item 1: `Kernel#warn` is a NO-OP when `$VERBOSE` is nil
+      # (`ruby -W0`, `RUBYOPT=-W0`, a caller wrapped in `Kernel#silence_warnings`)
+      # — every example in this file only ever proved the fallback worked
+      # because spec_helper.rb sets `config.warnings = false`, which affects
+      # RSpec's own deprecation-warning noise, NOT `$VERBOSE`. This example
+      # pins the fix directly: write to $stderr with $VERBOSE forced to nil,
+      # the exact condition under which `warn(...)` would have silently done
+      # nothing and reopened the f-l08-4 hole.
+      it "still writes to $stderr when $VERBOSE is nil (Kernel#warn would be a silent no-op here)" do
+        broken_writer = instance_double(Wild::CapabilityGate::Audit::JsonLinesWriter)
+        allow(broken_writer).to receive(:write).and_raise(IOError, "disk full")
+        ev = evaluator_with_broken_writer(broken_writer)
+
+        with_verbose(nil) do
+          expect do
+            ev.evaluate(caller_id: "service-account:introspection-agent", capability_name: :basic_introspection)
+          end.to output(/\[wild:capability_gate\] audit emission failed: IOError: disk full/).to_stderr
+        end
+      end
     end
+  end
+
+  def evaluator_with_broken_writer(broken_writer)
+    described_class.new(
+      registry: Wild::CapabilityGate::Registry.from_file(capabilities_path),
+      grants: Wild::CapabilityGate::Evaluator::GrantLoader.load_file(grants_path),
+      audit_writer: broken_writer
+    )
+  end
+
+  def with_verbose(value)
+    original = $VERBOSE
+    $VERBOSE = value
+    yield
+  ensure
+    $VERBOSE = original
   end
 
   def build_evaluator_with_prereq(prereq_path:)

--- a/spec/wild/capability_gate/evaluator_spec.rb
+++ b/spec/wild/capability_gate/evaluator_spec.rb
@@ -398,6 +398,27 @@ RSpec.describe Wild::CapabilityGate::Evaluator do
 
         expect(result).to be_allowed
       end
+
+      # f-l08-4: Wild.config.audit_logger defaults to nil (configuration.rb),
+      # so before this fix a single writer failure was terminally silent:
+      # log_audit_failure's `return unless logger.respond_to?(:error)` fired
+      # and there was nowhere else the failure was recorded, while the CHANGELOG
+      # claimed only a simultaneous writer-AND-logger outage was terminal.
+      # Kernel#warn ($stderr) is now the default-config fallback.
+      it "falls back to Kernel#warn on $stderr when no audit_logger is configured" do
+        broken_writer = instance_double(Wild::CapabilityGate::Audit::JsonLinesWriter)
+        allow(broken_writer).to receive(:write).and_raise(IOError, "disk full")
+
+        ev = described_class.new(
+          registry: Wild::CapabilityGate::Registry.from_file(capabilities_path),
+          grants: Wild::CapabilityGate::Evaluator::GrantLoader.load_file(grants_path),
+          audit_writer: broken_writer
+        )
+
+        expect do
+          ev.evaluate(caller_id: "service-account:introspection-agent", capability_name: :basic_introspection)
+        end.to output(/\[wild:capability_gate\] audit emission failed: IOError: disk full/).to_stderr
+      end
     end
   end
 

--- a/spec/wild/capability_gate/gate_spec.rb
+++ b/spec/wild/capability_gate/gate_spec.rb
@@ -146,15 +146,29 @@ RSpec.describe Wild::CapabilityGate::Gate do
     end
 
     # Armstrong F2 fast-follow contract (wild-wxk). The invariant being pinned:
-    # Evaluator#evaluate never raises (its own rescue emits the evaluation_error
-    # event + denies), so today the Gate's outer rescue is unreachable. That
-    # invariant is UNGUARDED — if a future refactor removes the Evaluator's
-    # rescue, the Gate's outer rescue becomes the backstop, and it is audit-blind
-    # BY CONSTRUCTION (the Gate holds no audit writer; emission lives in the
-    # Evaluator). The two examples above already pin that the backstop fails
-    # closed; the example below pins the displaced-hole's defining property —
-    # when the Gate rescue fires, NO audit event is written, so a missing event
-    # is the signal that the Evaluator's contract was violated.
+    # Evaluator#evaluate never raises for a genuine runtime/policy failure (its
+    # own rescue emits the evaluation_error event + denies), so this example
+    # exercises the Gate's outer StandardError rescue as the backstop for a
+    # future contract violation (a stubbed RuntimeError from the evaluator),
+    # not the "unreachable" backstop a prior version of this comment claimed.
+    #
+    # f-l08-3 correction: the Gate's outer rescue is NOT unreachable today: it
+    # WAS the only thing catching the AuditSchemaError that Evaluator#evaluate
+    # deliberately re-raises (see the `rescue AuditSchemaError, ConfigurationError;
+    # raise` clause now ordered above it in gate.rb#evaluate), silently
+    # demoting a "surface loudly" developer-bug signal into an audit-blind
+    # :evaluation_error denial. See the "raises AuditSchemaError instead of
+    # swallowing it" example below for that fixed path.
+    #
+    # This example's invariant (a genuine unexpected raise from the evaluator)
+    # is UNGUARDED: if a future refactor removes the Evaluator's rescue for
+    # that case, the Gate's outer rescue becomes the backstop, and it is
+    # audit-blind BY CONSTRUCTION (the Gate holds no audit writer; emission
+    # lives in the Evaluator). The two examples above already pin that the
+    # backstop fails closed; the example below pins the displaced-hole's
+    # defining property: when the Gate rescue fires, NO audit event is
+    # written, so a missing event is the signal that the Evaluator's contract
+    # was violated.
     #
     # NOTE on mechanism: the finding originally proposed `allow_any_instance_of`,
     # but Evaluator#initialize calls `freeze`, and RSpec cannot install a
@@ -174,6 +188,66 @@ RSpec.describe Wild::CapabilityGate::Gate do
 
       expect(result.reason).to eq(:evaluation_error)
       expect(File.read(log.path)).to be_empty # the displaced F2 hole: emission was bypassed
+    ensure
+      log.close!
+    end
+
+    # f-l08-3: proves the fix: Gate#evaluate now re-raises AuditSchemaError
+    # from the real (non-stubbed) Evaluator instead of swallowing it into an
+    # audit-blind :evaluation_error denial. Uses the same non-conforming-event
+    # injection technique as audit_liveness_spec.rb's toggle examples.
+    it "raises AuditSchemaError instead of swallowing it into a denial" do
+      Wild.configure { |c| c.capability_gate.validate_audit_events = true }
+      bad_event = instance_double(Wild::CapabilityGate::Audit::Event, to_h: { "outcome" => "maybe" })
+      allow(Wild::CapabilityGate::Audit::Event).to receive(:from_evaluation).and_return(bad_event)
+      log = Tempfile.new(["gate-schema", ".jsonl"])
+      gate = described_class.new(config_path: config_path, audit_log_path: log.path)
+
+      expect { gate.evaluate(caller: "svc:agent", capability: :basic_introspection) }
+        .to raise_error(Wild::CapabilityGate::AuditSchemaError)
+      expect(File.read(log.path)).to be_empty
+    ensure
+      log.close!
+    end
+  end
+
+  describe "#evaluate hostile context handling (f-l08-1)" do
+    # A caller-supplied non-Hash context used to raise TypeError inside
+    # Audit::Event#initialize's `Hash(context)`, get swallowed by the
+    # evaluator's StandardError rescue, and (with the default nil
+    # audit_logger) leave the ALLOW result with zero audit lines AND zero log
+    # lines. safe_context now coerces defensively before Event construction.
+    [
+      ["a String", "not-a-hash"],
+      ["a non-pair Array", %w[x y]],
+      ["nil", nil],
+      ["an object whose #to_hash raises", Class.new { def to_hash = raise("boom") }.new]
+    ].each do |label, hostile_context|
+      it "writes exactly one audit line per evaluate for #{label}" do
+        log = Tempfile.new(["gate-context", ".jsonl"])
+        gate = described_class.new(config_path: config_path, audit_log_path: log.path)
+
+        result = gate.evaluate(
+          caller: "svc:a", capability: :basic_introspection, context: hostile_context
+        )
+
+        expect(result).to be_allowed
+        expect(File.readlines(log.path).size).to eq(1)
+      ensure
+        log.close!
+      end
+    end
+
+    it "writes one line per call across repeated hostile-context evaluations" do
+      log = Tempfile.new(["gate-context-multi", ".jsonl"])
+      gate = described_class.new(config_path: config_path, audit_log_path: log.path)
+
+      first = gate.evaluate(caller: "svc:a", capability: :basic_introspection)
+      second = gate.evaluate(caller: "svc:a", capability: :basic_introspection, context: "not-a-hash")
+
+      expect(first).to be_allowed
+      expect(second).to be_allowed
+      expect(File.readlines(log.path).size).to eq(2)
     ensure
       log.close!
     end

--- a/spec/wild/capability_gate/gate_spec.rb
+++ b/spec/wild/capability_gate/gate_spec.rb
@@ -216,14 +216,28 @@ RSpec.describe Wild::CapabilityGate::Gate do
     # Audit::Event#initialize's `Hash(context)`, get swallowed by the
     # evaluator's StandardError rescue, and (with the default nil
     # audit_logger) leave the ALLOW result with zero audit lines AND zero log
-    # lines. safe_context now coerces defensively before Event construction.
+    # lines. Audit::Event.coerce_context now coerces defensively before Event
+    # construction.
+    #
+    # f-l08 addendum item 8: the original matrix had a dead ["nil", nil] row —
+    # `Hash(nil)` succeeds (returns {}) so it never exercises the placeholder
+    # path this describe block is about — and a wrong assumption that a
+    # pairs-shaped Array converts. Verified: `Kernel#Hash` raises TypeError for
+    # EVERY non-empty Array, pairs-shaped or not (`Hash([["a",1]])` raises
+    # exactly like `Hash(%w[x y])` does — Array implements neither #to_hash nor
+    # does Hash() fall back to #to_h). The "a pairs-shaped Array" row below
+    # replaces the dead one and proves that case degrades safely too, the same
+    # as any other non-empty Array.
     [
       ["a String", "not-a-hash"],
       ["a non-pair Array", %w[x y]],
-      ["nil", nil],
+      ["a pairs-shaped Array", [%w[a 1], %w[b 2]]],
       ["an object whose #to_hash raises", Class.new { def to_hash = raise("boom") }.new]
     ].each do |label, hostile_context|
-      it "writes exactly one audit line per evaluate for #{label}" do
+      # f-l08 addendum item 14: pin the invariant — one audit line, whose
+      # extra.context is exactly Audit::Event.coerce_context(hostile_context)
+      # — instead of only the weaker "hostile input still returns ALLOW".
+      it "writes exactly one audit line per evaluate for #{label}, with the coerced context recorded" do
         log = Tempfile.new(["gate-context", ".jsonl"])
         gate = described_class.new(config_path: config_path, audit_log_path: log.path)
 
@@ -231,8 +245,11 @@ RSpec.describe Wild::CapabilityGate::Gate do
           caller: "svc:a", capability: :basic_introspection, context: hostile_context
         )
 
+        lines = File.readlines(log.path)
         expect(result).to be_allowed
-        expect(File.readlines(log.path).size).to eq(1)
+        expect(lines.size).to eq(1)
+        expected_context = JSON.parse(JSON.generate(Wild::CapabilityGate::Audit::Event.coerce_context(hostile_context)))
+        expect(JSON.parse(lines.first).dig("extra", "context")).to eq(expected_context)
       ensure
         log.close!
       end


### PR DESCRIPTION
## What
- `SafeCoercion#safe_context` (never raises) runs before `Hash(context)` in `Evaluator#emit_audit`, so a hostile `context` (String, Array, nil, object whose `to_h` raises) still produces exactly one audit line per evaluation.
- `Audit::SchemaValidator`: when validation is enabled and `json_schemer` is absent, it raises `Wild::ConfigurationError` loudly instead of the `LoadError` being swallowed inside `emit_audit` (which returned ALLOW with zero audit and zero log).
- `Evaluator#evaluate`/`#emit_audit`, `Gate#evaluate` and `AdminTools::Identity::GateClient` re-raise the `DEVELOPER_ERRORS` family (`AuditSchemaError`, incl. the new `AuditValidatorUnavailableError`) above their blanket rescues; the comments and `gate_spec` that claimed the rescue was unreachable are corrected.
- `log_audit_failure` falls back to `Kernel#warn` when `Wild.config.audit_logger` is nil or has no `#error`, so a single writer failure is never terminally silent; the earlier F2 CHANGELOG bullet that overstated the guarantee is corrected.

## Why + decision rationale
Findings **f-l08-1 (P2, 2/2)**, **f-l08-2 (P1, hand-checked 2/2)**, **f-l08-3 (P1, 2/2)**, **f-l08-4 (P1, 2/2)** in `000-docs/010-RA-REVW-…`: three audit-blind ALLOW paths remained in the T3 gate after the F2 epic closed, two introduced by #41/#42. Chose **a narrow `AuditSchemaError` subclass over re-raising the gem-wide `ConfigurationError`** (the first commit's shape) because the wide class would let an unrelated configuration error from a prerequisite checker escape `evaluate` before its audit event; and **re-raising through `GateClient`** because letting the loud error be swallowed one layer up would reopen the same hole; `Gate#initialize` already promises it does not silently swallow configuration errors (docstring updated: `evaluate` is no longer "never raises" for these two developer-bug cases). The DENY-vs-`audit_degraded` posture for a dark audit path is deliberately **not** chosen here (owner decision bead *Decide the fail-closed posture for ALLOW results when both the audit writer and logger are dark*); `emit_audit` still returns the computed result after warning.

## Layer(s) touched
`Wild::CapabilityGate` (T3) only. No edge change. Contract change: `Gate#evaluate` can raise `AuditSchemaError` / `ConfigurationError`.

## How it works
Coerce → evaluate → emit exactly one audit event → on writer failure log through the configured logger or stderr → return the decision. Schema/config errors are developer bugs and propagate.

## Verification & evidence
- Failing on main: `gate_spec.rb` "hostile context handling (f-l08-1)" + "raises AuditSchemaError instead of swallowing it into a denial"; `audit_liveness_spec.rb` "json_schemer absent (f-l08-2)" + "falls back to $stderr (f-l08-4)"; `evaluator_spec.rb` "falls back to Kernel#warn"; `schema_validator_spec.rb` ".validate! when json_schemer is not available". Repro: `bundle exec rspec spec/wild/capability_gate/gate_spec.rb -e "hostile context"`. Original repros re-run by hand: f-l08-1 audit_lines=2 (main: 1); f-l08-2/3 raise loudly (main: silent ALLOW); f-l08-4 prints `[wild:capability_gate] audit emission failed: …` to stderr (main: nothing).
- Branch: `bundle exec rspec` → 3150 examples, 0 failures (seeds default, 1, 41803); `bundle exec rubocop` → 497 files, 0 offenses.
- Paired verifiers on `c76f2e9` (comment): `/security-review` MEDIUM (`Kernel#warn` silenced under `-W0`) and `/code-review high` (~15 items). All folded into fix-up `34b578f`: `$stderr.puts` fallback (spec runs with `$VERBOSE = nil`); `SchemaValidator.enabled?` consults `Rails.env` for `:auto` and `Gate#initialize` probes json_schemer availability at boot; new `AuditValidatorUnavailableError < AuditSchemaError` so `DEVELOPER_ERRORS = [AuditSchemaError]` is the narrow whitelist (an unrelated `ConfigurationError` inside a prerequisite checker still yields a fail-closed denial with an audit event); `GateClient` re-raises developer errors with a log line instead of demoting them to `gate_denied`; context coerced once at the top of `evaluate` (checker and audit see the same value) with `Event.coerce_context` as the total-construction backstop (dup, never freezes the caller's Hash; class-dispatched bounded placeholder passed through the hooks Sanitizer; JSON-size/NaN bounding; `SystemStackError` cannot escape); `JsonLinesWriter` re-serializes with a placeholder context on generator errors; `event.to_h` built once; docstrings corrected; `@api private` tags; specs rewritten around the one-audit-line invariant including a capability with a `config_value` prerequisite.
- Fix-up verification: `bundle exec rspec` → 3177 examples, 0 failures (seeds default and 1); affected specs on seeds 1 and 41803 → 352/0; `bundle exec rubocop` → 497 files, 0 offenses. A second `/security-review` pass on `34b578f` is posted as a comment before merge. CI run URL: the `CI OK` check on this head.

## Risk assessment
T3 security surface (+ one T4 file, `GateClient`). Consumers in development/test without `json_schemer` now fail loudly at `Gate#initialize` (previously silent ALLOW): intended; production (`Rails.env.production?`) keeps validation off. `Gate#evaluate` and `GateClient#authorize` can raise the `AuditSchemaError` family. Public surface adds `Event.coerce_context`, `AuditValidatorUnavailableError`, `DEVELOPER_ERRORS`. Rollback: revert the squash commit.

## Operational impact
Dev/test consumers must have `json_schemer` available or disable validation explicitly; production default unchanged (validation off unless enabled).

## Follow-up & deferred
- f-l08-5 (probe `audit_log_path` writability at Gate construction): own pass, same cluster.
- f-l08-9/10/11 (prerequisite checkers resolve against `Dir.pwd`; nil caller becomes `""` and matches a wildcard grant; loader errors subclass bare `StandardError`): P2 backlog on the cluster issue.
- Posture decision: owner bead above.

## Governance links
Cluster: *Fix the capability gate audit-blind paths: coerce context, re-raise schema errors, never allow in silence* (#62). Advances bead *Move wild-capability-gate into Wild::CapabilityGate and fix the F2 audit-blind path*. Council fix F2 (narrowly closed → these were the reopened paths).

Refs #62
