### PR TITLE
fix(telemetry): match JSON-quoted and hash-rocket secret keys in the content filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,29 @@ section splits into a separate file.
   holds this logic (split out of `Redactor` to stay under
   `Metrics/ClassLength`). Advances bead "F7: Add boundary normalization
   wherever data crosses namespaces".
+- **`ContentFilter::API_KEY_PATTERN` and `AWS_SECRET_KEY_PATTERN` now match
+  JSON-quoted and hash-rocket secret shapes, not just bare `key=value`**
+  (review wave, finding f-l03-2). Both patterns required the key name
+  followed by optional whitespace then `:`/`=` directly, so a closing quote
+  between the key and the separator, the shape `JSON.generate` and Ruby
+  hash literals produce (`"api_key":"sk_live_..."`, `'api_key' => 'sk_live_...'`),
+  never matched: `ClaudeCodeAdapter#extract_tool_use_content` builds turn
+  content as `name(#{JSON.generate(input)})`, so any tool call carrying a
+  secret in its `input` put that secret into content in exactly this
+  unmatched shape, past `Export::JsonExporter` unredacted (the turn's
+  metadata copy of the same secret was already covered by f-l03-1's
+  `MetadataRedactor`, content was not). Both patterns now name a `prefix`
+  and `suffix` capture around the secret value, tolerating an optional
+  closing quote and whitespace before the separator (`:`, `=`, or `=>`) and
+  an optional opening quote after it; `Redactor#redact_pattern` replaces
+  only the captured value when those named groups are present (built-in or
+  a caller's own key-anchored custom pattern), so `"api_key":"sk_live_..."`
+  redacts to `"api_key":"[REDACTED]"` and stays parseable JSON, rather than
+  the whole `key:value` span collapsing into a bare marker. `GITHUB_TOKEN_PATTERN`,
+  `AWS_ACCESS_KEY_PATTERN`, and `BEARER_TOKEN_PATTERN` needed no change:
+  none of them anchor on a key name, so they already matched the token
+  value alone inside surrounding quotes. Advances bead "F7: Add boundary
+  normalization wherever data crosses namespaces".
 - **HIGH regression fixed: derived `Intent#description` leaked secrets past
   the redaction boundary, and `#redact_content` was not idempotent against
   its own marker** (security-review follow-up on the item above, f-l03-1).

--- a/lib/wild/telemetry/pipeline/privacy/content_filter.rb
+++ b/lib/wild/telemetry/pipeline/privacy/content_filter.rb
@@ -7,9 +7,17 @@ module Wild
         class ContentFilter
           EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/
           IP_PATTERN = /\b(?:\d{1,3}\.){3}\d{1,3}\b/
-          API_KEY_PATTERN = /\b(?:api[_-]?key|apikey|api_secret)\s*[:=]\s*['"]?[A-Za-z0-9_-]{16,}['"]?/i
+          # Key-anchored: `prefix` captures the key name plus whatever
+          # quoting/separator surrounds it (bare `api_key=`, JSON-quoted
+          # `"api_key":"`, or hash-rocket `'api_key' => '`), `suffix`
+          # captures an optional closing quote. Redactor#redact_pattern uses
+          # both named groups to redact only the secret value, so a
+          # JSON/Ruby-hash shape stays parseable after redaction (f-l03-2).
+          API_KEY_PATTERN =
+            /\b(?<prefix>(?:api[_-]?key|apikey|api_secret)['"]?\s*[:=]>?\s*['"]?)[A-Za-z0-9_-]{16,}(?<suffix>['"]?)/i
           AWS_ACCESS_KEY_PATTERN = /\b(?:AKIA|ASIA|AROA)[A-Z0-9]{16}\b/
-          AWS_SECRET_KEY_PATTERN = %r{\b(?:aws[_-]secret|secret_access_key)\s*[:=]\s*['"]?[A-Za-z0-9+/]{40}['"]?}i
+          AWS_SECRET_KEY_PATTERN =
+            %r{\b(?<prefix>(?:aws[_-]secret|secret_access_key)['"]?\s*[:=]>?\s*['"]?)[A-Za-z0-9+/]{40}(?<suffix>['"]?)}i
           GITHUB_TOKEN_PATTERN = /\bghp_[A-Za-z0-9]{36}\b|\bghs_[A-Za-z0-9]{36}\b/
           BEARER_TOKEN_PATTERN = %r{\bBearer\s+[A-Za-z0-9._\-+/=]{20,}}i
           ABSOLUTE_PATH_PATTERN = %r{\b(?:/(?:[^/\s]+/)*[^/\s]+)\b}

--- a/lib/wild/telemetry/pipeline/privacy/redactor.rb
+++ b/lib/wild/telemetry/pipeline/privacy/redactor.rb
@@ -104,8 +104,24 @@ module Wild
             end
           end
 
+          # A key-anchored pattern (built-in, e.g. ContentFilter::API_KEY_PATTERN,
+          # or a custom pattern the caller wrote the same way) declares named
+          # `prefix`/`suffix` captures so only the secret value is replaced,
+          # leaving the key name and any surrounding quotes intact: redacting
+          # `"api_key":"sk_live_..."` must yield `"api_key":"[REDACTED]"`, not
+          # a blob that swallows the key name and breaks the JSON/hash shape
+          # the adapter emitted (f-l03-2). Patterns without those captures
+          # keep the original whole-match replacement.
           def redact_pattern(content, pattern, marker)
-            content.gsub(pattern, marker)
+            if key_anchored?(pattern)
+              content.gsub(pattern) { "#{Regexp.last_match(:prefix)}#{marker}#{Regexp.last_match(:suffix)}" }
+            else
+              content.gsub(pattern, marker)
+            end
+          end
+
+          def key_anchored?(pattern)
+            pattern.is_a?(Regexp) && pattern.names.include?("prefix") && pattern.names.include?("suffix")
           end
 
           def redact_file_contents(content, marker)

--- a/spec/wild/telemetry/pipeline/integration/full_pipeline_spec.rb
+++ b/spec/wild/telemetry/pipeline/integration/full_pipeline_spec.rb
@@ -107,6 +107,28 @@ RSpec.describe "Full pipeline integration" do
       expect(exported).not_to include("10.1.2.3")
       expect(exported).to include("\"redacted\":true")
     end
+
+    it "redacts a JSON-quoted secret in the adapter's own tool_use content shape " \
+       "end to end (f-l03-2)" do
+      # ClaudeCodeAdapter#extract_tool_use_content builds turn content as
+      # "name(#{JSON.generate(input)})", so a tool_use with a secret in
+      # `input` puts that secret into content as JSON-quoted text
+      # (`"api_key":"..."`), not the bare `api_key=...` shape the content
+      # filter's key-anchored patterns matched before this fix. The same
+      # `input` also lands in turn metadata (already covered by f-l03-1's
+      # MetadataRedactor), so this asserts neither export surface leaks it.
+      line = {
+        type: "tool_use",
+        name: "deploy",
+        input: { "api_key" => "sk_live_abcdefghijklmnop" }
+      }.to_json
+
+      transcripts = Wild::Telemetry::Pipeline.process(line, adapter: adapter, source_id: "session-json-secret")
+      exported = json_exporter.export(transcripts)
+
+      expect(exported).not_to include("sk_live_abcdefghijklmnop")
+      expect(exported).to include("[REDACTED]")
+    end
   end
 
   describe "MCP log pipeline" do

--- a/spec/wild/telemetry/pipeline/privacy/redactor_spec.rb
+++ b/spec/wild/telemetry/pipeline/privacy/redactor_spec.rb
@@ -332,4 +332,69 @@ RSpec.describe Wild::Telemetry::Pipeline::Privacy::Redactor do
       expect(twice).to eq(once)
     end
   end
+
+  describe "#redact_content key-anchored secret shapes (f-l03-2)" do
+    # API_KEY_PATTERN required the key name followed by optional whitespace
+    # then `:`/`=` directly, so a closing quote between the key and the
+    # separator (the shape JSON.generate and Ruby hash literals produce)
+    # never matched: the JSON-quoted case here fails on main, the bare
+    # shapes at the bottom already passed there. Table-driven so every shape
+    # the fix's docstring claims to cover is exercised, not just the one the
+    # adapter happens to emit today.
+    # Hardcoded per shape/example rather than shared through an outer local:
+    # RSpec/LeakyLocalVariable flags a value assigned outside an example and
+    # read inside one, since it can be mutated across examples that share
+    # the closure. Each string below is a literal, not a shared reference.
+    [
+      ["JSON-quoted, compact",        %("api_key":"sk_live_abcdefghijklmnop")],
+      ["JSON-quoted, spaced",         %("api_key": "sk_live_abcdefghijklmnop")],
+      ["Ruby hash rocket",            %('api_key' => 'sk_live_abcdefghijklmnop')],
+      ["bare key, colon",             "api_key: sk_live_abcdefghijklmnop"],
+      ["bare key, equals",            "api_key=sk_live_abcdefghijklmnop"],
+      ["uppercase bare key, quoted",  %(API_KEY="sk_live_abcdefghijklmnop")]
+    ].each do |label, content|
+      it "redacts the secret value for the #{label} shape" do
+        result = redactor.redact_content(content)
+
+        expect(result).not_to include("sk_live_abcdefghijklmnop")
+        expect(result).to include("[REDACTED]")
+      end
+
+      it "keeps the key name for the #{label} shape" do
+        result = redactor.redact_content(content)
+
+        expect(result).to match(/api_key/i)
+      end
+    end
+
+    it "keeps the exported JSON parseable when the secret sits in a JSON-quoted key/value pair" do
+      content = %({"api_key":"sk_live_abcdefghijklmnop","other":"value"})
+
+      result = redactor.redact_content(content)
+
+      expect { JSON.parse(result) }.not_to raise_error
+      parsed = JSON.parse(result)
+      expect(parsed["api_key"]).to eq("[REDACTED]")
+      expect(parsed["other"]).to eq("value")
+    end
+
+    it "is idempotent for the JSON-quoted shape (redacting twice equals redacting once)" do
+      content = %("api_key":"sk_live_abcdefghijklmnop")
+
+      once = redactor.redact_content(content)
+      twice = redactor.redact_content(once)
+
+      expect(twice).to eq(once)
+    end
+
+    it "redacts a JSON-quoted AWS secret_access_key the same way" do
+      aws_secret = "A" * 40
+      content = %("secret_access_key":"#{aws_secret}")
+
+      result = redactor.redact_content(content)
+
+      expect(result).not_to include(aws_secret)
+      expect(result).to eq(%("secret_access_key":"[REDACTED]"))
+    end
+  end
 end


### PR DESCRIPTION
## What
- `ContentFilter::API_KEY_PATTERN` and `AWS_SECRET_KEY_PATTERN` gain named `prefix`/`suffix` captures so `"api_key": "…"`, `'api_key' => '…'`, `api_key: …`, `api_key=…`, `API_KEY="…"` all match.
- `Redactor#redact_pattern` replaces only the captured value when a pattern is key-anchored (keeps the key and quotes, so JSON stays parseable); non-anchored patterns keep whole-match replacement.
- Table-driven spec over six shapes + JSON-parseability + idempotency; an end-to-end spec through `Pipeline.process` + `JsonExporter` with a `tool_use` input containing `"api_key":"sk_live_…"`.

## Why + decision rationale
Finding **f-l03-2 (P1, 2/3 lenses)**: the JSON-quoted shape `ClaudeCodeAdapter` itself emits via `JSON.generate` never matched, so the secret survived in content (metadata is covered since #68 by the key-aware `MetadataRedactor`). Chose **generalizing value-only replacement to any pattern with `prefix`/`suffix` groups** (built-in or custom) over special-casing the two built-ins, so a custom key-anchored pattern gets the same behavior; that implicit contract is documented in the code comment.

## Layer(s) touched
`Wild::Telemetry::Pipeline` (T2) privacy layer. No edge change.

## Verification & evidence
- Failing on main: `spec/wild/telemetry/pipeline/privacy/redactor_spec.rb:322+` ("key-anchored secret shapes (f-l03-2)"); the old pattern returns `match? == false` for `"api_key":"sk_live_abcdefghijklmnop"`.
- Branch: `bundle exec rspec` → 3173 examples, 0 failures; affected files on seeds 1 and 41803 → 118/0; `bundle exec rubocop` → 497 files, 0 offenses.
- CI run URL: the `CI OK` check on this head. Paired verifier: `/code-review high` verdict posted as a comment before merge.

## Risk assessment
Redaction output for key-anchored shapes now keeps the key name (`"api_key":"[REDACTED]"`) instead of replacing the whole `key=value` span; consumers matching the old whole-span output see a different string. Rollback: revert the squash commit.

## Operational impact
None.

## Follow-up & deferred
- f-l03-6 (`ContentFilter#sensitive?` / `#patterns_matching` have no production callers): wire-or-delete left for the owner; wiring would create a second copy of the pattern list, deleting rewrites `content_filter_spec`.
- `GITHUB_TOKEN`/`AWS_ACCESS_KEY`/`BEARER` patterns match the value shape directly and already tolerate quoting (no change).

## Governance links
Cluster: *Fix the telemetry pipeline privacy findings: redact turn metadata and match JSON-quoted secret keys* (#57), second and last PR. Advances bead *F7: Add boundary normalization wherever data crosses namespaces*. Council fix F7.

Closes #57