### PR TITLE
fix(introspection): enforce capability policy and surface audit gaps

### DIFF
--- a/lib/wild/configuration.rb
+++ b/lib/wild/configuration.rb
@@ -98,6 +98,7 @@ module Wild
 
     CapabilityGate = Struct.new(
       :capabilities_path,
+      :policy_path,
       :on_evaluation_error,
       :validate_audit_events,
       keyword_init: true
@@ -105,6 +106,10 @@ module Wild
       def initialize(**kwargs)
         super(
           capabilities_path: kwargs.fetch(:capabilities_path, nil),
+          # Directory containing capabilities.yml and grants.yml. Consumers
+          # that route a privileged namespace through CapabilityGate must set
+          # this explicitly; an unset policy is fail-closed, never allow-all.
+          policy_path: kwargs.fetch(:policy_path, nil),
           # CURRENTLY INERT (Armstrong F2 gate, wild-28y): Evaluator#evaluate
           # unconditionally fails closed (deny + audit, never raises) and does
           # NOT read this knob. The :hard_fail default documents intent but does

--- a/lib/wild/introspection/audit/audit_logger.rb
+++ b/lib/wild/introspection/audit/audit_logger.rb
@@ -6,12 +6,19 @@ module Wild
   module Introspection
     module Audit
       module AuditLogger
+        # rubocop:disable Naming/PredicateMethod -- logging is a command whose
+        # boolean result reports whether persistence occurred.
         def self.log(audit_record)
           path = Wild::Introspection.configuration.audit_log_path
-          return unless path
+          unless path
+            warn("[wild:introspection] audit record not persisted: audit_log_path is not configured")
+            return false
+          end
 
           File.open(path, "a") { |f| f.puts(JSON.generate(audit_record.to_h)) }
+          true
         end
+        # rubocop:enable Naming/PredicateMethod
       end
     end
   end

--- a/lib/wild/introspection/identity/capability_gate.rb
+++ b/lib/wild/introspection/identity/capability_gate.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "singleton"
+
 module Wild
   module Introspection
     module Identity
@@ -7,16 +9,16 @@ module Wild
       # whether a caller has the capability to perform a specific action on
       # a specific resource.
       #
-      # In v1, this is a transparent stub: all authenticated callers are
-      # permitted all actions. When wild-capability-gate ships, this module
-      # becomes the integration point — replace the stub logic with a real
-      # gate check without changing the call sites.
+      # This adapter routes authenticated callers through Wild::CapabilityGate.
+      # A host must explicitly configure policy_path (a directory containing
+      # capabilities.yml and grants.yml); an unset or invalid policy denies.
       #
       # Integration contract for Epic 10:
       #   CapabilityGate.permitted?(request_context, action:, resource:) → boolean
       #
       # See 009-AT-ADEC-capability-gate-interface.md for the full contract.
       module CapabilityGate
+        REQUIRED_CAPABILITY = :basic_introspection
         CAPABILITY_DENIAL = {
           status: :denied,
           reason: :insufficient_capability,
@@ -36,15 +38,45 @@ module Wild
         # @param resource [String, nil] the target resource (e.g. model name)
         # @return [Boolean] true if the caller is permitted
         def self.permitted?(request_context, action:, resource: nil) # rubocop:disable Lint/UnusedMethodArgument
-          # v1 stub: all authenticated callers have full capability.
-          # When wild-capability-gate ships, this becomes:
-          #   WildCapabilityGate.check(request_context.caller_id, action: action, resource: resource)
-          request_context.authenticated?
+          return false unless request_context.authenticated?
+
+          gate.evaluate(caller: request_context.caller_id, capability: REQUIRED_CAPABILITY).allowed?
+        rescue StandardError => e
+          warn("[wild:introspection] capability gate denied evaluation: #{e.class}")
+          false
+        end
+
+        def self.reset!
+          @gate = nil
+          @policy_path = nil
         end
 
         # Returns the standard denial response for capability check failure.
         def self.denial_response
           CAPABILITY_DENIAL
+        end
+
+        def self.gate
+          policy_path = Wild.config.capability_gate.policy_path
+          return DenyAllGate.instance if policy_path.nil?
+
+          @gate = nil if @policy_path != policy_path
+          @policy_path = policy_path
+          @gate ||= Wild::CapabilityGate.new(config_path: policy_path)
+        end
+        private_class_method :gate
+
+        class DenyAllGate
+          include Singleton
+
+          def evaluate(**)
+            Wild::CapabilityGate::EvaluationResult.denied(
+              capability_name: REQUIRED_CAPABILITY,
+              caller_id: "unconfigured",
+              reason: :policy_unavailable,
+              details: "capability gate policy_path is not configured"
+            )
+          end
         end
       end
     end

--- a/spec/support/wild_introspection/test_config_helper.rb
+++ b/spec/support/wild_introspection/test_config_helper.rb
@@ -5,9 +5,12 @@ module Wild
     module TestSupport
       module TestConfigHelper
         FIXTURES_PATH = File.expand_path("fixtures", __dir__)
+        CAPABILITY_GATE_FIXTURES_PATH = File.expand_path("../../fixtures/config", __dir__)
         TEST_API_KEY = "sk-test-valid-key"
 
         def configure_with_test_fixtures!
+          Wild.config.capability_gate.policy_path = CAPABILITY_GATE_FIXTURES_PATH
+          Wild::Introspection::Identity::CapabilityGate.reset!
           Wild::Introspection.configure do |config|
             config.access_policy_path = File.join(FIXTURES_PATH, "access_policy.yml")
             config.blocked_resources_path = File.join(FIXTURES_PATH, "blocked_resources.yml")

--- a/spec/wild/introspection/audit/audit_logger_spec.rb
+++ b/spec/wild/introspection/audit/audit_logger_spec.rb
@@ -67,8 +67,9 @@ RSpec.describe Wild::Introspection::Audit::AuditLogger do
       Wild::Introspection.configuration.audit_log_path = nil
     end
 
-    it "silently skips logging" do
-      expect { described_class.log(record) }.not_to raise_error
+    it "does not silently skip logging" do
+      expect { described_class.log(record) }
+        .to output(/audit record not persisted: audit_log_path is not configured/).to_stderr
       expect(File.exist?(log_path)).to be false
     end
   end

--- a/spec/wild/introspection/identity/capability_gate_spec.rb
+++ b/spec/wild/introspection/identity/capability_gate_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Wild::Introspection::Identity::CapabilityGate do
     context "with an authenticated caller" do
       let(:ctx) { authenticated_context }
 
-      it "permits all actions in v1" do
+      it "permits each action only through the configured basic_introspection grant" do
         described_class::ACTIONS.each do |action|
           expect(described_class.permitted?(ctx, action: action, resource: "Account")).to be(true)
         end
@@ -17,6 +17,19 @@ RSpec.describe Wild::Introspection::Identity::CapabilityGate do
 
       it "permits actions without a resource" do
         expect(described_class.permitted?(ctx, action: "inspect_model_schema")).to be(true)
+      end
+    end
+
+    context "when no capability policy is configured" do
+      let(:ctx) { authenticated_context }
+
+      before do
+        Wild.config.capability_gate.policy_path = nil
+        described_class.reset!
+      end
+
+      it "fails closed instead of treating authentication as authorization" do
+        expect(described_class.permitted?(ctx, action: "inspect_model_schema")).to be(false)
       end
     end
 


### PR DESCRIPTION
Closes #63\n\nRoutes authenticated introspection callers through an explicitly configured CapabilityGate policy; missing policy fails closed. AuditLogger now emits a stderr diagnostic when no audit path is configured instead of silently dropping the record.\n\nValidation: focused identity, tool-handler, audit logger, and configuration RSpec (68 examples); focused RuboCop; diff check.