### PR TITLE
refactor(admin_tools): use the shared hooks audit sanitizer

### DIFF
--- a/lib/wild/admin_tools/audit/parameter_sanitizer.rb
+++ b/lib/wild/admin_tools/audit/parameter_sanitizer.rb
@@ -1,56 +1,18 @@
 # frozen_string_literal: true
 
-require "digest"
+require "wild/hooks/audit/sanitizer"
 
 module Wild
   module AdminTools
     module Audit
-      class ParameterSanitizer
-        REDACTED = "[REDACTED]"
-        HASHED_PREFIX = "[SHA256:"
-
-        DEFAULT_REDACT_KEYS = %w[
-          password secret token api_key private_key
-          ssn social_security credit_card card_number
-          email phone address
-        ].freeze
-
-        DEFAULT_HASH_KEYS = %w[
-          job_id actor_id user_id account_id
-        ].freeze
-
-        def initialize(redact_keys: DEFAULT_REDACT_KEYS, hash_keys: DEFAULT_HASH_KEYS)
-          @redact_keys = Set.new(redact_keys.map(&:to_s))
-          @hash_keys = Set.new(hash_keys.map(&:to_s))
-        end
-
-        def sanitize(params)
-          return {} if params.blank?
-
-          params.each_with_object({}) do |(key, value), sanitized|
-            key_s = key.to_s
-            sanitized[key] = sanitize_value(key_s, value)
-          end
-        end
-
-        private
-
-        def sanitize_value(key, value)
-          if @redact_keys.any? { |rk| key.include?(rk) }
-            REDACTED
-          elsif @hash_keys.any? { |hk| key.include?(hk) }
-            hash_value(value)
-          elsif value.is_a?(Hash)
-            sanitize(value)
-          else
-            value
-          end
-        end
-
-        def hash_value(value)
-          digest = Digest::SHA256.hexdigest(value.to_s)[0, 8]
-          "#{HASHED_PREFIX}#{digest}]"
-        end
+      # Compatibility name for the shared Hooks audit sanitizer.
+      #
+      # AdminTools is a Tier 4 consumer of the Tier 1 Hooks substrate, so it
+      # must not carry a second redaction grammar. Keeping this subclass
+      # preserves the public constructor/injection seam while all key
+      # normalization, recursive array handling, hashing, and secret matching
+      # are owned by Wild::Hooks::Audit::Sanitizer.
+      class ParameterSanitizer < Wild::Hooks::Audit::Sanitizer
       end
     end
   end


### PR DESCRIPTION
Implements verifier follow-up wild-vfo.3.12.3. AdminTools retains ParameterSanitizer as a compatibility subclass but delegates the implementation to the Tier 1 Hooks substrate, eliminating divergent key matching and recursive handling.\n\nValidation: focused RSpec (56 examples); focused RuboCop; diff check.