### PR TITLE
fix(hooks): activate shared commit message validation

### DIFF
--- a/.beads-hooks/commit-msg
+++ b/.beads-hooks/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+# The repository hook is versioned under scripts/; this dispatcher remains in
+# the active shared hooks path selected by `bd hooks install --shared`.
+exec "$(git rev-parse --show-toplevel)/scripts/git-hooks/commit-msg" "$@"

--- a/.beads-hooks/post-checkout
+++ b/.beads-hooks/post-checkout
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+if command -v bd >/dev/null 2>&1; then
+  bd hooks run post-checkout "$@"
+  hook_status=$?
+  if [ "$hook_status" -ne 0 ] && [ "$hook_status" -ne 3 ]; then
+    exit "$hook_status"
+  fi
+fi

--- a/.beads-hooks/post-merge
+++ b/.beads-hooks/post-merge
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+if command -v bd >/dev/null 2>&1; then
+  bd hooks run post-merge "$@"
+  hook_status=$?
+  if [ "$hook_status" -ne 0 ] && [ "$hook_status" -ne 3 ]; then
+    exit "$hook_status"
+  fi
+fi

--- a/.beads-hooks/pre-commit
+++ b/.beads-hooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+# Versioned Beads + repository hook chain. `bd hooks install --shared --chain`
+# refreshes the managed Beads section while preserving this command.
+if command -v bd >/dev/null 2>&1; then
+  bd hooks run pre-commit "$@"
+  hook_status=$?
+  if [ "$hook_status" -ne 0 ] && [ "$hook_status" -ne 3 ]; then
+    exit "$hook_status"
+  fi
+fi
+exec "$(git rev-parse --show-toplevel)/scripts/git-hooks/pre-commit" "$@"

--- a/.beads-hooks/pre-push
+++ b/.beads-hooks/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+# Versioned Beads + repository hook chain. `bd hooks install --shared --chain`
+# refreshes the managed Beads section while preserving this command.
+if command -v bd >/dev/null 2>&1; then
+  bd hooks run pre-push "$@"
+  hook_status=$?
+  if [ "$hook_status" -ne 0 ] && [ "$hook_status" -ne 3 ]; then
+    exit "$hook_status"
+  fi
+fi
+exec "$(git rev-parse --show-toplevel)/scripts/git-hooks/pre-push" "$@"

--- a/.beads-hooks/prepare-commit-msg
+++ b/.beads-hooks/prepare-commit-msg
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+if command -v bd >/dev/null 2>&1; then
+  bd hooks run prepare-commit-msg "$@"
+  hook_status=$?
+  if [ "$hook_status" -ne 0 ] && [ "$hook_status" -ne 3 ]; then
+    exit "$hook_status"
+  fi
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ cd wild
 # Install dependencies
 bin/setup
 
-# Wire local git hooks (one-time per clone — pre-commit RuboCop, commit-msg
-# conventional-commits, pre-push RSpec smoke)
+# Wire shared Beads and repository hooks (one-time per clone — pre-commit
+# RuboCop, commit-msg conventional-commits, pre-push RSpec smoke)
 scripts/install-hooks
 
 # Run the test suite
@@ -46,7 +46,9 @@ bundle exec bundler-audit check --update
 
 ### Local git hooks
 
-`scripts/install-hooks` symlinks three plain-shell hooks into `.git/hooks/`:
+`scripts/install-hooks` activates the committed `.beads-hooks/` chain with
+`bd hooks install --shared --chain`. It keeps Beads lifecycle hooks and the
+repository's conventional-commit, RuboCop, and RSpec checks active together.
 
 | Hook | What it does | Bypass |
 |---|---|---|

--- a/scripts/install-hooks
+++ b/scripts/install-hooks
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# install-hooks — symlink scripts/git-hooks/* into .git/hooks/
+# install-hooks — activate the shared Beads + repository hook chain.
 #
 # Run once per clone. Idempotent — safe to re-run.
 # To skip a hook: `git commit --no-verify` / `git push --no-verify`.
@@ -8,8 +8,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-HOOKS_SRC="$REPO_ROOT/scripts/git-hooks"
-HOOKS_DST="$REPO_ROOT/.git/hooks"
+HOOKS_DST="$REPO_ROOT/.beads-hooks"
 
 if [ ! -d "$REPO_ROOT/.git" ]; then
   echo "install-hooks: no .git/ at $REPO_ROOT — not a git checkout?" >&2
@@ -17,42 +16,26 @@ if [ ! -d "$REPO_ROOT/.git" ]; then
 fi
 
 if [ "${1:-}" = "--uninstall" ]; then
-  for hook in pre-commit commit-msg pre-push; do
-    target="$HOOKS_DST/$hook"
-    if [ -L "$target" ] && [ "$(readlink "$target")" = "$HOOKS_SRC/$hook" ]; then
-      rm "$target"
-      echo "removed: $target"
-    fi
-  done
+  git config --unset core.hooksPath 2>/dev/null || true
+  echo "removed: core.hooksPath"
   exit 0
 fi
 
-mkdir -p "$HOOKS_DST"
+if ! command -v bd >/dev/null 2>&1; then
+  echo "install-hooks: bd is required to install the shared Beads hook chain." >&2
+  exit 2
+fi
+
+# `--shared` selects the committed .beads-hooks/ path. `--chain` refreshes the
+# managed Beads sections while preserving the repository dispatchers outside
+# those markers (including commit-msg, which Beads does not manage itself).
+bd hooks install --shared --chain
 
 for hook in pre-commit commit-msg pre-push; do
-  src="$HOOKS_SRC/$hook"
-  dst="$HOOKS_DST/$hook"
-
-  if [ ! -x "$src" ]; then
-    chmod +x "$src"
+  if [ ! -x "$HOOKS_DST/$hook" ]; then
+    chmod +x "$HOOKS_DST/$hook"
   fi
-
-  # If destination is already our symlink, skip
-  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
-    echo "ok:      $hook (already linked)"
-    continue
-  fi
-
-  # If destination exists and isn't our symlink, back it up
-  if [ -e "$dst" ] && [ ! -L "$dst" ]; then
-    backup="$dst.local.$(date +%s)"
-    mv "$dst" "$backup"
-    echo "backup:  $dst -> $backup"
-  fi
-
-  ln -sf "$src" "$dst"
-  echo "linked:  $hook"
 done
 
 echo
-echo "All hooks installed. To bypass a single commit: git commit --no-verify"
+echo "Shared Beads and repository hooks installed. To bypass a single commit: git commit --no-verify"


### PR DESCRIPTION
Restores the committed Conventional Commit check by moving active hooks to the versioned shared Beads hooks path. The shared dispatchers retain Beads lifecycle hooks and invoke the repository pre-commit/pre-push checks. The installer now configures that shared chain for each clone.\n\nValidation: shell syntax checks; direct valid and invalid commit-message hook paths; actual invalid git commit rejection; pre-push RSpec smoke 4 examples, 0 failures.