### PR TITLE
refactor(audit): centralize failure reporting

### DIFF
--- a/lib/wild.rb
+++ b/lib/wild.rb
@@ -3,6 +3,7 @@
 require "wild/version"
 require "wild/error"
 require "wild/configuration"
+require "wild/audit_failure_log"
 require "wild/engine"
 require "wild/hooks"
 require "wild/capability_gate"

--- a/lib/wild/audit_failure_log.rb
+++ b/lib/wild/audit_failure_log.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Wild
+  # Last-resort reporting for failures in audit and observability sinks.
+  #
+  # This is deliberately a root-package utility: Hooks and Telemetry cannot
+  # depend on CapabilityGate, but all three need the same never-raise,
+  # never-silently-drop behavior when their configured logger is unavailable.
+  module AuditFailureLog
+    class << self
+      def record(tag:, error:, detail:, level: :error, suffix: nil)
+        line = build_line(tag: tag, error: error, detail: detail, suffix: suffix)
+        logger = Wild.config.audit_logger
+
+        if logger.respond_to?(level)
+          logger.public_send(level, line)
+        else
+          write_stderr(line)
+        end
+      rescue StandardError
+        # A broken logger must not turn an already-isolated audit failure into
+        # an application failure. Reuse the line if it was safely built; the
+        # class-only fallback avoids asking a pathological exception for its
+        # message a second time.
+        write_stderr(line || "[wild:#{safe_tag(tag)}] audit failure: #{safe_class(error)}")
+      end
+
+      private
+
+      def build_line(tag:, error:, detail:, suffix:)
+        "[wild:#{safe_tag(tag)}] #{detail}: #{safe_class(error)}: #{safe_message(error)}#{suffix}"
+      end
+
+      def safe_tag(tag)
+        String(tag)
+      rescue StandardError
+        "unknown"
+      end
+
+      def safe_class(error)
+        error.class
+      rescue StandardError
+        StandardError
+      end
+
+      def safe_message(error)
+        error.message
+      rescue StandardError
+        "<unprintable message>"
+      end
+
+      # rubocop:disable Style/StderrPuts -- warn is silent when $VERBOSE is nil.
+      def write_stderr(line)
+        $stderr.puts(line)
+      rescue StandardError
+        nil
+      end
+      # rubocop:enable Style/StderrPuts
+    end
+  end
+end

--- a/lib/wild/capability_gate/evaluator.rb
+++ b/lib/wild/capability_gate/evaluator.rb
@@ -59,11 +59,6 @@ module Wild
     # 4. ALLOW
     #
     # See also: 003-TQ-STND-governance-model.md (fail-closed, no implicit grants)
-    # rubocop:disable Metrics/ClassLength -- carries the full decision tree AND
-    # the f-l08 addendum's audit-failure logging helpers (log_audit_failure/
-    # write_stderr/build_audit_failure_message); those exist only to serve this
-    # class's own never-raises guarantee, so splitting them out would separate
-    # the guarantee from its enforcement.
     class Evaluator
       include SafeCoercion
 
@@ -243,58 +238,15 @@ module Wild
         # before StandardError, exactly as the schema-conformance case does.
         raise
       rescue StandardError => e
-        log_audit_failure(e, result)
+        Wild::AuditFailureLog.record(
+          tag: "capability_gate",
+          error: e,
+          detail: "audit emission failed",
+          suffix: " (caller=#{result.caller_id.inspect} capability=#{result.capability_name.inspect} " \
+                  "reason=#{result.reason.inspect})"
+        )
         nil
-      end
-
-      # Log an audit emission failure without ever raising (this method's own
-      # caller, emit_audit's rescue, must not raise either — that would defeat
-      # the never-raises guarantee). f-l08-4: Wild.config.audit_logger defaults
-      # to nil, so without a fallback a single writer failure was terminally
-      # silent while ALLOW/DENY was still returned.
-      #
-      # f-l08 addendum item 1: `Kernel#warn` is a no-op when `$VERBOSE` is nil
-      # (`ruby -W0`, `RUBYOPT=-W0`, a caller that runs under `silence_warnings`)
-      # — the specs here only ever passed because spec_helper.rb sets
-      # `config.warnings = false`, which does NOT affect `$VERBOSE`. Writing to
-      # `$stderr` directly keeps "audit failure is never doubly silent" true
-      # regardless of the process's warning-verbosity setting; only an
-      # unwritable $stderr defeats this last resort.
-      def log_audit_failure(error, result)
-        message = build_audit_failure_message(error, result)
-        logger = Wild.config.audit_logger
-        logger.respond_to?(:error) ? logger.error(message) : write_stderr(message)
-      rescue StandardError
-        # The configured logger raised from #error, or message construction
-        # itself raised (message stays nil in that case — Ruby has already
-        # declared the local by the time this rescue runs). Reuse the message
-        # we already built when we have one instead of rebuilding it (which
-        # would risk raising the exact same way twice); fall back to a
-        # class-only line when we don't.
-        write_stderr(message || "[wild:capability_gate] audit emission failed: #{error.class}")
-      end
-
-      # @api private
-      # rubocop:disable Style/StderrPuts -- deliberate: `warn` is a Kernel#warn
-      # no-op under $VERBOSE = nil (ruby -W0, silence_warnings), which is
-      # exactly the f-l08 addendum item 1 finding this bypasses.
-      def write_stderr(line)
-        $stderr.puts(line)
-      rescue StandardError
-        nil
-      end
-      # rubocop:enable Style/StderrPuts
-
-      # error.class is always safe; error.message is guarded via safe_message
-      # (a pathological exception whose #message raises must not turn a
-      # should-have-logged into terminal silence). Armstrong F2 fast-follow
-      # finding 4 (wild-wxk).
-      def build_audit_failure_message(error, result)
-        "[wild:capability_gate] audit emission failed: #{error.class}: #{safe_message(error)} " \
-          "(caller=#{result.caller_id.inspect} capability=#{result.capability_name.inspect} " \
-          "reason=#{result.reason.inspect})"
       end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/wild/hooks/execution/runner.rb
+++ b/lib/wild/hooks/execution/runner.rb
@@ -76,48 +76,12 @@ module Wild
           return unless status == :error
 
           @observability_failures_mutex.synchronize { @observability_failures += 1 }
-          log_observability_failure(hook_name, handler, sink_name, error)
-        end
-
-        def log_observability_failure(hook_name, handler, sink_name, error)
-          line = observability_failure_line(hook_name, handler, sink_name, error)
-          logger = Wild.config.audit_logger
-
-          if logger.respond_to?(:error)
-            logger.error(line)
-          else
-            # No audit_logger is configured (the shipped default). Falling
-            # through silently here would leave observability_failures as a
-            # counter nobody reads, which is the same F2 anti-pattern this
-            # method exists to avoid. warn keeps the default install loud.
-            warn(line)
-          end
-        rescue StandardError
-          # The configured logger is itself broken. There is nowhere left to
-          # write; do not raise out of the Runner. observability_failures was
-          # already incremented above, so the failure remains countable even
-          # when the log line itself cannot be emitted.
-          nil
-        end
-
-        def observability_failure_line(hook_name, handler, sink_name, error)
-          # error.class is always safe; error.message is guarded via
-          # #safe_message below (a pathological exception whose #message
-          # itself raises must not silently drop the whole log line).
-          "[wild:hooks] #{sink_name} observability sink failed for hook=#{hook_name.inspect} " \
-            "handler=#{handler&.id.to_s.inspect}: #{error.class}: #{safe_message(error)}"
-        end
-
-        # #message on an arbitrary rescued exception is not guaranteed safe
-        # (a pathological exception can override it to raise). Degrade to a
-        # placeholder rather than lose the whole should-have-logged line.
-        # Mirrors Wild::CapabilityGate::Evaluator::SafeCoercion#safe_message
-        # (copied, not required: T1 hooks must not depend on T3
-        # capability_gate per ADR-0003).
-        def safe_message(error)
-          error.message
-        rescue StandardError
-          "<unprintable message>"
+          Wild::AuditFailureLog.record(
+            tag: "hooks",
+            error: error,
+            detail: "#{sink_name} observability sink failed for hook=#{hook_name.inspect} " \
+                    "handler=#{handler&.id.to_s.inspect}"
+          )
         end
 
         def execute_handler(handler, context)

--- a/lib/wild/telemetry/collector/collector/event_receiver.rb
+++ b/lib/wild/telemetry/collector/collector/event_receiver.rb
@@ -73,42 +73,19 @@ module Wild
           end
 
           def log_storage_failure(error)
-            logger = Wild.config.audit_logger
-            return unless logger.respond_to?(:error)
-
-            logger.error(
-              "[wild:telemetry:collector] event store append failed: " \
-              "#{error.class}: #{safe_message(error)} (event dropped, fire-and-forget)"
+            Wild::AuditFailureLog.record(
+              tag: "telemetry:collector",
+              error: error,
+              detail: "event store append failed (event dropped, fire-and-forget)"
             )
-          rescue StandardError
-            # The configured logger is itself broken. There is nowhere left
-            # to record this; the counter above already made the failure
-            # observable without depending on the logger working.
-            nil
           end
 
           def log_internal_error(error)
-            logger = Wild.config.audit_logger
-            return unless logger.respond_to?(:error)
-
-            logger.error(
-              "[wild:telemetry:collector] unexpected internal error while storing event: " \
-              "#{error.class}: #{safe_message(error)} (event dropped, fire-and-forget)"
+            Wild::AuditFailureLog.record(
+              tag: "telemetry:collector",
+              error: error,
+              detail: "unexpected internal error while storing event (event dropped, fire-and-forget)"
             )
-          rescue StandardError
-            # Same rationale as #log_storage_failure: a broken logger has
-            # nowhere left to record this, and there is no counter to fall
-            # back on for internal errors, but re-raising here would turn a
-            # should-have-been-caught error into an uncaught one.
-            nil
-          end
-
-          # #message on an arbitrary rescued exception is not guaranteed safe
-          # (mirrors Wild::CapabilityGate::Evaluator#safe_message).
-          def safe_message(error)
-            error.message
-          rescue StandardError
-            "<unprintable message>"
           end
         end
       end

--- a/spec/wild/audit_failure_log_spec.rb
+++ b/spec/wild/audit_failure_log_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::AuditFailureLog do
+  after { Wild.reset_config! }
+
+  it "writes a standardized line to the configured logger" do
+    logger = instance_double(Logger, error: nil)
+    Wild.configure { |config| config.audit_logger = logger }
+
+    described_class.record(tag: "hooks", error: IOError.new("disk full"), detail: "sink failed")
+
+    expect(logger).to have_received(:error)
+      .with("[wild:hooks] sink failed: IOError: disk full")
+  end
+
+  it "falls back to stderr when no compatible logger is configured" do
+    expect do
+      described_class.record(tag: "telemetry", error: IOError.new("disk full"), detail: "store failed")
+    end.to output(/\[wild:telemetry\] store failed: IOError: disk full/).to_stderr
+  end
+
+  it "never raises when the error message and configured logger both raise" do
+    error = Class.new(StandardError) do
+      def message = raise("message unavailable")
+    end.new
+    logger = instance_double(Logger)
+    allow(logger).to receive(:error).and_raise("logger unavailable")
+    Wild.configure { |config| config.audit_logger = logger }
+
+    expect { described_class.record(tag: "hooks", error: error, detail: "sink failed") }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Extracts Wild::AuditFailureLog into the root package and routes capability-gate, hooks, and telemetry audit-failure reporting through it. The helper preserves safe error-message coercion, configured logger dispatch, stderr fallback, and never-raise behavior; package-specific counters and fire-and-forget behavior remain local.\n\nValidation: focused 113 examples; full RSpec 3317 examples, 0 failures; RuboCop 507 files, no offenses; Packwerk validate/check clean; Brakeman 0 warnings; Bundler Audit 0 vulnerabilities.