### PR TITLE
fix(telemetry): lock JSON lines rewrites across processes

### DIFF
--- a/lib/wild/telemetry/collector/store/json_lines_store.rb
+++ b/lib/wild/telemetry/collector/store/json_lines_store.rb
@@ -25,7 +25,9 @@ module Wild
           def append(envelope)
             line = JSON.generate(envelope.to_h)
             @mutex.synchronize do
-              File.open(@path, "a") { |f| f.puts(line) }
+              with_file_lock do
+                File.open(@path, "a") { |f| f.puts(line) }
+              end
             end
             envelope
           rescue SystemCallError, IOError => e
@@ -79,7 +81,9 @@ module Wild
 
           def clear!
             @mutex.synchronize do
-              atomic_replace("") if File.exist?(@path)
+              with_file_lock do
+                atomic_replace("") if File.exist?(@path)
+              end
             end
           rescue SystemCallError, IOError => e
             raise StorageError, "clear failed: #{e.class}: #{e.message}"
@@ -109,24 +113,25 @@ module Wild
           # `File.open(tmp, "wb")` picks up umask-default permissions and the
           # calling uid instead).
           #
-          # The lock this rewrite runs under (@mutex, shared with #append) is
-          # process-local: it does nothing for two separate processes (or
-          # two separate JsonLinesStore instances) writing the same file
-          # concurrently, there is no flock, and none is added here.
-          # Cross-process purge/append safety on a shared file is a
-          # follow-up (bead: "Add cross-process file locking to
-          # JsonLinesStore for multi-process purge/append safety").
+          # The process-local mutex is paired with an advisory flock on a
+          # stable sidecar file. Locking @path itself would be incorrect:
+          # atomic_replace renames a new inode over @path, so another process
+          # could retain a lock on the old inode and append to the new one.
+          # The sidecar lock serializes append, compact, and clear! across
+          # distinct store instances and Ruby processes.
           def compact
             @mutex.synchronize do
-              return 0 unless File.exist?(@path)
+              with_file_lock do
+                return 0 unless File.exist?(@path)
 
-              lines = File.readlines(@path)
-              kept_lines = yield(lines)
-              removed_count = lines.length - kept_lines.length
-              return 0 if removed_count.zero?
+                lines = File.readlines(@path)
+                kept_lines = yield(lines)
+                removed_count = lines.length - kept_lines.length
+                return 0 if removed_count.zero?
 
-              atomic_replace(kept_lines.join)
-              removed_count
+                atomic_replace(kept_lines.join)
+                removed_count
+              end
             end
           rescue SystemCallError, IOError => e
             raise StorageError, "compact failed: #{e.class}: #{e.message}"
@@ -136,6 +141,19 @@ module Wild
 
           def ensure_directory!
             FileUtils.mkdir_p(File.dirname(@path))
+          end
+
+          def with_file_lock
+            File.open("#{@path}.lock", File::RDWR | File::CREAT, 0o600) do |lock|
+              lock.flock(File::LOCK_EX)
+              yield
+            ensure
+              begin
+                lock.flock(File::LOCK_UN)
+              rescue StandardError
+                nil
+              end
+            end
           end
 
           def atomic_replace(content)

--- a/spec/wild/telemetry/collector/store/json_lines_store_spec.rb
+++ b/spec/wild/telemetry/collector/store/json_lines_store_spec.rb
@@ -5,6 +5,7 @@
 require "spec_helper"
 require "tmpdir"
 require "fileutils"
+require "timeout"
 
 RSpec.describe Wild::Telemetry::Collector::Store::JsonLinesStore do
   let(:tmpdir) { Dir.mktmpdir("json_lines_store_spec") }
@@ -364,6 +365,37 @@ RSpec.describe Wild::Telemetry::Collector::Store::JsonLinesStore do
         surviving_actions = store.query.map(&:action).select { |a| a.start_with?("survivor_") }
         expect(surviving_actions.uniq.size).to eq(survivor_count)
       end
+
+      # rubocop:disable RSpec/ExampleLength, Style/FileOpen -- explicit lock lifetime is the assertion.
+      it "serializes an append from another process behind the stable sidecar lock" do
+        reader, writer = IO.pipe
+        lock = File.open("#{store_path}.lock", File::RDWR | File::CREAT, 0o600)
+        lock.flock(File::LOCK_EX)
+
+        pid = fork do
+          reader.close
+          described_class.new(path: store_path).append(build_envelope(action: "child_process"))
+          writer.write("done")
+          writer.close
+        end
+        writer.close
+
+        expect(reader.wait_readable(0.1)).to be_nil
+
+        lock.flock(File::LOCK_UN)
+        lock.close
+        expect(Timeout.timeout(5) { reader.read }).to eq("done")
+        Process.wait(pid)
+        pid = nil
+
+        expect(store.query.map(&:action)).to include("child_process")
+      ensure
+        reader&.close unless reader&.closed?
+        writer&.close unless writer&.closed?
+        lock&.close unless lock&.closed?
+        Process.wait(pid) if pid && Process.waitpid(pid, Process::WNOHANG).nil?
+      end
+      # rubocop:enable RSpec/ExampleLength, Style/FileOpen
     end
   end
 end


### PR DESCRIPTION
Adds a stable sidecar flock around JsonLinesStore append, compact, and clear. The sidecar remains stable across atomic data-file replacement, preventing append/rewrite data loss between separate Ruby processes.\n\nValidation: focused store and retention suite 50 examples, 0 failures, including a forked-process lock proof; full RSpec 3318 examples, 0 failures; RuboCop 507 files clean; Packwerk validate/check clean; Brakeman 0 warnings; Bundler Audit 0 vulnerabilities.