### PR TITLE
fix(hooks): bound observability logs and tune sanitizer

### DIFF
--- a/lib/wild/hooks/audit/sanitizer.rb
+++ b/lib/wild/hooks/audit/sanitizer.rb
@@ -43,6 +43,15 @@ module Wild
           job_id actor_id user_id account_id
         ].freeze
 
+        # Exact normalized keys that are operational metadata rather than
+        # secrets or stable identities. This prevents substring matching from
+        # redacting useful values such as max_tokens (token), email_template
+        # (email), and contractor_id (actor_id) while leaving similarly named
+        # sensitive fields protected.
+        DEFAULT_ALLOW_KEYS = %w[
+          max_tokens token_count ip_address email_template contractor_id
+        ].freeze
+
         # Matches a `key=value` token inside a free-form string (e.g. an
         # exception message), so #sanitize_string can redact secret-looking
         # substrings that never passed through #sanitize as a structured
@@ -55,9 +64,11 @@ module Wild
         #   any key containing one of these gets REDACTED
         # @param hash_keys [Array<String, Symbol>] substring patterns —
         #   any key containing one of these gets SHA-256 hashed
-        def initialize(redact_keys: DEFAULT_REDACT_KEYS, hash_keys: DEFAULT_HASH_KEYS)
+        def initialize(redact_keys: DEFAULT_REDACT_KEYS, hash_keys: DEFAULT_HASH_KEYS,
+                       allow_keys: DEFAULT_ALLOW_KEYS)
           @redact_keys = Set.new(redact_keys.map { |k| normalize_key(k) })
           @hash_keys   = Set.new(hash_keys.map { |k| normalize_key(k) })
+          @allow_keys  = Set.new(allow_keys.map { |k| normalize_key(k) })
         end
 
         # Sanitize a hash of parameters, returning a new hash with the
@@ -98,19 +109,27 @@ module Wild
         private
 
         def sanitize_value(key, value)
-          normalized = normalize_key(key)
-
-          if @redact_keys.any? { |rk| normalized.include?(rk) }
-            REDACTED
-          elsif @hash_keys.any? { |hk| normalized.include?(hk) }
-            hash_value(value)
-          elsif value.is_a?(Hash)
-            sanitize(value)
-          elsif value.is_a?(Array)
-            sanitize_array(value)
-          else
-            value
+          case key_action(normalize_key(key))
+          when :allow then value
+          when :redact then REDACTED
+          when :hash then hash_value(value)
+          else sanitize_nested_value(value)
           end
+        end
+
+        def key_action(normalized)
+          return :allow if @allow_keys.include?(normalized)
+          return :redact if @redact_keys.any? { |key| normalized.include?(key) }
+          return :hash if @hash_keys.any? { |key| normalized.include?(key) }
+
+          :pass
+        end
+
+        def sanitize_nested_value(value)
+          return sanitize(value) if value.is_a?(Hash)
+          return sanitize_array(value) if value.is_a?(Array)
+
+          value
         end
 
         def sanitize_array(array)

--- a/lib/wild/hooks/execution/runner.rb
+++ b/lib/wild/hooks/execution/runner.rb
@@ -75,13 +75,21 @@ module Wild
           status, error = @isolator.call(&)
           return unless status == :error
 
-          @observability_failures_mutex.synchronize { @observability_failures += 1 }
+          failure_count = @observability_failures_mutex.synchronize do
+            @observability_failures += 1
+          end
+          return unless power_of_two?(failure_count)
+
           Wild::AuditFailureLog.record(
             tag: "hooks",
             error: error,
             detail: "#{sink_name} observability sink failed for hook=#{hook_name.inspect} " \
                     "handler=#{handler&.id.to_s.inspect}"
           )
+        end
+
+        def power_of_two?(number)
+          number.positive? && number.nobits?(number - 1)
         end
 
         def execute_handler(handler, context)

--- a/spec/wild/hooks/audit/sanitizer_spec.rb
+++ b/spec/wild/hooks/audit/sanitizer_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe Wild::Hooks::Audit::Sanitizer do
         out = sanitizer.sanitize(email: "a@b.com", phone: "555", address: "1 Main St")
         expect(out.values).to all(eq(described_class::REDACTED))
       end
+
+      it "keeps exact operational keys despite overlapping substring patterns" do
+        out = sanitizer.sanitize(
+          max_tokens: 500, token_count: 42, ip_address: "203.0.113.8",
+          email_template: "receipt", contractor_id: "contractor-7"
+        )
+
+        expect(out).to eq(
+          max_tokens: 500, token_count: 42, ip_address: "203.0.113.8",
+          email_template: "receipt", contractor_id: "contractor-7"
+        )
+      end
     end
 
     describe "hashing" do
@@ -164,5 +176,11 @@ RSpec.describe Wild::Hooks::Audit::Sanitizer do
       expect(out[:traceable_value]).to start_with(described_class::HASHED_PREFIX)
       expect(out[:user_id]).to eq(42) # default pattern no longer active
     end
+  end
+
+  it "allows hooks consumers to extend the exact-key operational allowlist" do
+    custom = described_class.new(allow_keys: %w[retry_token_count])
+
+    expect(custom.sanitize(retry_token_count: 3)[:retry_token_count]).to eq(3)
   end
 end

--- a/spec/wild/hooks/execution/runner_spec.rb
+++ b/spec/wild/hooks/execution/runner_spec.rb
@@ -319,6 +319,16 @@ RSpec.describe Wild::Hooks::Execution::Runner do
         expect { runner.execute("before_tool_call", {}) }
           .to output(/hook="before_tool_call".*handler="#{Regexp.escape(handler_id)}"/).to_stderr
       end
+
+      it "logs the first failure and powers of two while retaining the exact failure count" do
+        configured_logger = instance_double(Logger, error: nil)
+        allow(Wild.config).to receive(:audit_logger).and_return(configured_logger)
+
+        5.times { runner.execute("before_tool_call", {}) }
+
+        expect(configured_logger).to have_received(:error).exactly(3).times
+        expect(runner.observability_failures).to eq(5)
+      end
     end
 
     context "when a sink raises Timeout::Error (verifier follow-up 8)" do


### PR DESCRIPTION
Logs broken observability sinks at the first failure and power-of-two counts while preserving the exact counter. Adds an exact normalized-key operational allowlist so max_tokens, token_count, ip_address, email_template, and contractor_id are not over-redacted by broad substring rules.\n\nValidation: focused Hooks suite 58 examples, 0 failures; full RSpec 3321 examples, 0 failures; RuboCop 507 files clean; Packwerk validate/check clean; Brakeman 0 warnings; Bundler Audit 0 vulnerabilities.