### PR TITLE
fix(telemetry): surface storage failures in health monitor

### DIFF
--- a/lib/wild/telemetry/collector/collector/event_receiver.rb
+++ b/lib/wild/telemetry/collector/collector/event_receiver.rb
@@ -29,14 +29,15 @@ module Wild
           # error and does not inflate the storage-failure counter, so an
           # operator alerting on that counter is alerting on genuine
           # disk/IO problems, not on arbitrary store bugs.
-          attr_reader :storage_failure_count
+          attr_reader :storage_monitor
 
-          def initialize(store:, validator: nil, filter: nil)
+          delegate :storage_failure_count, to: :storage_monitor
+
+          def initialize(store:, validator: nil, filter: nil, storage_monitor: nil)
             @store = store
             @validator = validator || Schema::Validator.new
             @filter = filter || Privacy::Filter.new
-            @storage_failure_count = 0
-            @counter_mutex = Mutex.new
+            @storage_monitor = storage_monitor || Store::StorageMonitor.new(store: store)
           end
 
           def receive(event)
@@ -64,7 +65,7 @@ module Wild
           end
 
           def record_storage_failure(error)
-            @counter_mutex.synchronize { @storage_failure_count += 1 }
+            @storage_monitor.record_storage_failure(error)
             log_storage_failure(error)
           end
 

--- a/lib/wild/telemetry/collector/store/storage_monitor.rb
+++ b/lib/wild/telemetry/collector/store/storage_monitor.rb
@@ -7,6 +7,8 @@ module Wild
         class StorageMonitor
           def initialize(store:)
             @store = store
+            @storage_failure_count = 0
+            @failure_mutex = Mutex.new
           end
 
           def stats
@@ -15,14 +17,27 @@ module Wild
               size_bytes: size_bytes,
               oldest_event: oldest_event_timestamp,
               newest_event: newest_event_timestamp,
+              storage_failure_count: storage_failure_count,
               store_type: @store.class.name
             }
           end
 
           def healthy?
-            @store.count >= 0
+            @store.count >= 0 && storage_failure_count.zero?
           rescue StandardError
             false
+          end
+
+          # Records a storage-layer failure reported by EventReceiver. This
+          # is deliberately distinct from arbitrary adapter bugs so the health
+          # signal means the configured telemetry store is failing, not merely
+          # that application code raised while attempting an append.
+          def record_storage_failure(_error = nil)
+            @failure_mutex.synchronize { @storage_failure_count += 1 }
+          end
+
+          def storage_failure_count
+            @failure_mutex.synchronize { @storage_failure_count }
           end
 
           private

--- a/spec/wild/telemetry/collector/collector/event_receiver_spec.rb
+++ b/spec/wild/telemetry/collector/collector/event_receiver_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe Wild::Telemetry::Collector::Collector::EventReceiver do
       store = instance_double(Wild::Telemetry::Collector::Store::MemoryStore)
       allow(store).to receive(:append)
         .and_raise(Wild::Telemetry::Collector::StorageError, "append failed: Errno::ENOSPC: disk full")
+      allow(store).to receive_messages(count: 0, recent: [])
       store
     end
 
@@ -110,6 +111,13 @@ RSpec.describe Wild::Telemetry::Collector::Collector::EventReceiver do
     it "counts the storage failure distinctly from a validation reject (finding f-l02-3)" do
       expect { receiver.receive(valid_action_completed_event) }
         .to change(receiver, :storage_failure_count).from(0).to(1)
+    end
+
+    it "exposes the failure through its StorageMonitor health surface" do
+      receiver.receive(valid_action_completed_event)
+
+      expect(receiver.storage_monitor.stats[:storage_failure_count]).to eq(1)
+      expect(receiver.storage_monitor).not_to be_healthy
     end
 
     it "does not count a validation reject as a storage failure" do
@@ -146,6 +154,7 @@ RSpec.describe Wild::Telemetry::Collector::Collector::EventReceiver do
     let(:buggy_store) do
       store = instance_double(Wild::Telemetry::Collector::Store::MemoryStore)
       allow(store).to receive(:append).and_raise(NoMethodError, "undefined method `to_h' for a custom adapter bug")
+      allow(store).to receive(:count).and_return(0)
       store
     end
 
@@ -160,6 +169,12 @@ RSpec.describe Wild::Telemetry::Collector::Collector::EventReceiver do
 
     it "does not count it as a storage failure" do
       expect { receiver.receive(valid_action_completed_event) }.not_to change(receiver, :storage_failure_count)
+    end
+
+    it "does not mark the StorageMonitor unhealthy for an adapter bug" do
+      receiver.receive(valid_action_completed_event)
+
+      expect(receiver.storage_monitor).to be_healthy
     end
 
     it "logs it as an internal error, distinct from a storage failure, at :error" do

--- a/spec/wild/telemetry/collector/store/storage_monitor_spec.rb
+++ b/spec/wild/telemetry/collector/store/storage_monitor_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe Wild::Telemetry::Collector::Store::StorageMonitor do
       it "returns nil for newest_event" do
         expect(monitor.stats[:newest_event]).to be_nil
       end
+
+      it "returns zero storage failures" do
+        expect(monitor.stats[:storage_failure_count]).to eq(0)
+      end
     end
 
     context "with a JsonLinesStore containing events" do
@@ -116,6 +120,27 @@ RSpec.describe Wild::Telemetry::Collector::Store::StorageMonitor do
 
       it "returns false" do
         expect(monitor.healthy?).to be(false)
+      end
+    end
+
+    context "when an EventReceiver reports a storage failure" do
+      let(:failing_store) do
+        store = Wild::Telemetry::Collector::Store::MemoryStore.new
+        allow(store).to receive(:append).and_raise(Wild::Telemetry::Collector::StorageError, "disk full")
+        store
+      end
+      let(:monitor) { described_class.new(store: failing_store) }
+      let(:receiver) do
+        Wild::Telemetry::Collector::Collector::EventReceiver.new(
+          store: failing_store, storage_monitor: monitor
+        )
+      end
+
+      it "surfaces the drop count and fails the health check" do
+        receiver.receive(valid_action_completed_event)
+
+        expect(monitor.stats[:storage_failure_count]).to eq(1)
+        expect(monitor).not_to be_healthy
       end
     end
   end


### PR DESCRIPTION
Routes EventReceiver StorageError signals through StorageMonitor. Stats now report storage_failure_count; healthy? becomes false after a real storage failure while non-storage adapter bugs remain distinct. Receiver keeps storage_failure_count as a compatibility delegate.\n\nValidation: focused receiver/monitor suite 43 examples, 0 failures; full RSpec 3325 examples, 0 failures; RuboCop 507 files clean; Packwerk validate/check clean; Brakeman 0 warnings; Bundler Audit 0 vulnerabilities.