### PR TITLE
fix(skillops): enforce internal enabled policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -831,6 +831,12 @@ section splits into a separate file.
 
 ### Wild::Skillops
 
+- **Made the F5 internal-by-default posture executable** (review follow-up,
+  `wild-rvv.8.1`). `Wild::Skillops.build` now raises
+  `Wild::Skillops::DisabledError` until an application explicitly sets
+  `Wild.config.skillops.enabled = true`; the default setting is no longer an
+  inert documentation claim. Skillops behavior specs opt in deliberately.
+
 - Moved 20 source files from `wild-skillops-registry/lib/wild_skillops_registry/`
   into `lib/wild/skillops/` under the `Wild::Skillops::*` namespace (Role 5
   PR-5). Layout preserved verbatim: `models/`, `registry/`, `versioning/`,

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The namespaces:
 | `Wild::Hooks` | Hook lifecycle + concerns shared across namespaces |
 | `Wild::Analyzers::Permission` | Permission model analyzer (CLI + library) |
 | `Wild::Analyzers::TestFlakes` | Test flake forensics (CLI + library) |
-| `Wild::Skillops` | Skill/capability registry (internal — earn separate gem when external consumer appears) |
+| `Wild::Skillops` | Skill/capability registry (internal and disabled by default; set `config.skillops.enabled = true` to opt in, then earn a separate gem when an external consumer appears) |
 
 ## Origin
 

--- a/lib/wild/error.rb
+++ b/lib/wild/error.rb
@@ -300,6 +300,10 @@ module Wild
     # Base for every Wild::Skillops failure mode.
     class Error < Wild::Error; end
 
+    # Raised when an application invokes the internal Skillops registry without
+    # explicitly opting in through `Wild.config.skillops.enabled`.
+    class DisabledError < Error; end
+
     # Raised when a skill registration payload fails validation.
     class ValidationError < Error; end
 

--- a/lib/wild/skillops.rb
+++ b/lib/wild/skillops.rb
@@ -54,7 +54,16 @@ module Wild
   module Skillops
     # Build a fully-wired registry instance. Returns a RegistryFacade
     # exposing all subsystems through one object.
+    #
+    # Skillops is internal until a consumer deliberately opts in. Keeping this
+    # guard at the public factory—not at file require time—lets the rest of
+    # Wild boot normally while making the F5 default operational.
     def self.build
+      unless Wild.config.skillops.enabled
+        raise DisabledError,
+              "Wild::Skillops is disabled by default; set Wild.config.skillops.enabled = true to opt in"
+      end
+
       store     = Registry::Store.new
       tag_index = Discovery::TagIndex.new
       RegistryFacade.new(**build_components(store, tag_index))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -136,4 +136,11 @@ RSpec.configure do |config|
   config.before do
     Wild.reset_config! if Wild.respond_to?(:reset_config!)
   end
+
+  # Skillops is intentionally internal and disabled by default. Its own
+  # behavior specs exercise the explicit consumer opt-in; policy specs can
+  # still reset configuration and assert the disabled default directly.
+  config.before(file_path: %r{spec/wild/skillops/}) do
+    Wild.configure { |settings| settings.skillops.enabled = true }
+  end
 end

--- a/spec/wild/skillops_enabled_policy_spec.rb
+++ b/spec/wild/skillops_enabled_policy_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Wild::Skillops do
+  it "rejects the public factory while the internal namespace is disabled" do
+    Wild.reset_config!
+
+    expect { described_class.build }
+      .to raise_error(Wild::Skillops::DisabledError, /disabled by default/)
+  end
+
+  it "builds only after an application explicitly opts in" do
+    Wild.configure { |settings| settings.skillops.enabled = true }
+
+    expect(described_class.build).to be_a(Wild::Skillops::RegistryFacade)
+  end
+end


### PR DESCRIPTION
## Summary
- makes the council F5 `skillops.enabled = false` default executable at `Wild::Skillops.build`
- adds a dedicated `Wild::Skillops::DisabledError` and explicit opt-in path
- preserves internal behavior specs through deliberate test-only opt-in

## Verification
- `bundle exec rspec` — 3,327 examples, 0 failures
- `bundle exec rubocop` — 508 files, 0 offenses
- `bundle exec packwerk validate && bundle exec packwerk check` — clean
- `bundle exec brakeman --force -p . --skip-files spec/` — 0 warnings
- `bundle exec bundle-audit check --update` — 0 vulnerabilities

Closes `wild-rvv.8.1` after merge.